### PR TITLE
Мини рефактор сцп 999 + фикс возможности схватиться за сцп999 стену

### DIFF
--- a/Content.Client/_Scp/Scp999/Scp999System.cs
+++ b/Content.Client/_Scp/Scp999/Scp999System.cs
@@ -13,8 +13,6 @@ public sealed class Scp999System : SharedScp999System
         SubscribeNetworkEvent<Scp999RestEvent>(OnRest);
     }
 
-    // TODO: отключение базовых лейеров, так как они их видно при смене спрайта.
-
     private void OnWallify(Scp999WallifyEvent args)
     {
         var uid = GetEntity(args.NetEntity);

--- a/Content.Shared/_Scp/Scp999/SharedScp999System.cs
+++ b/Content.Shared/_Scp/Scp999/SharedScp999System.cs
@@ -16,26 +16,26 @@ public abstract class SharedScp999System : EntitySystem
         SubscribeLocalEvent<Scp999Component, ExaminedEvent>(OnExamined);
     }
 
-    private static void OnCanSee(EntityUid uid, Scp999Component component, ref CanSeeAttemptEvent args)
+    private static void OnCanSee(Entity<Scp999Component> entity, ref CanSeeAttemptEvent args)
     {
-        if (component.CurrentState == Scp999States.Rest)
+        if (entity.Comp.CurrentState == Scp999States.Rest)
             args.Cancel();
     }
 
-    private static void OnSpeakAttempt(EntityUid uid, Scp999Component component, ref SpeakAttemptEvent args)
+    private static void OnSpeakAttempt(Entity<Scp999Component> entity, ref SpeakAttemptEvent args)
     {
-        if (component.CurrentState == Scp999States.Rest)
+        if (entity.Comp.CurrentState == Scp999States.Rest)
             args.Cancel();
     }
 
-    private void OnExamined(EntityUid uid, Scp999Component component, ref ExaminedEvent args)
+    private void OnExamined(Entity<Scp999Component> entity, ref ExaminedEvent args)
     {
         if (!args.IsInDetailsRange)
             return;
 
-        if (component.CurrentState != Scp999States.Rest)
+        if (entity.Comp.CurrentState != Scp999States.Rest)
             return;
 
-        args.PushMarkup(Loc.GetString("sleep-examined", ("target", Identity.Entity(uid, EntityManager))));
+        args.PushMarkup(Loc.GetString("sleep-examined", ("target", Identity.Entity(entity, EntityManager))));
     }
 }


### PR DESCRIPTION
<!-- Пожалуйста прочитайте эту статью перед тем как выложить PR, чтобы избежать лишних правок в процессе осмотра: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- Текст в стрелочках является комментариями - они не будут видны в вашем PR. -->

## Кратное описание
<!-- Что вы предлагаете изменить с помощью своего PR? -->

- Убрал возможность игроку схватиться за сцп 999 в форме стены, так как человека в таком виде невозможно отцепить, не застанив или не убив.

## Рефактор

- Перевел подписки на ивенты на подписки нового образца с Entity<>
- Вынес GetNetEntity за свитч, чтобы не вписывать эту длинную конструкцию 2 раза
- Убрал савмил с серверной системы 999, так как он не используется
- Выделил айди фикстуры наверх системы, чтобы потом было проще менять

## По какой причине
<!-- В чём причина добавления этих изменений? Ссылки на Дискуссии, а так-же Баг-Репорты указывать здесь. Пожалуйста опишите как это изменит игровой баланс. -->

## Медиа(Видео/Скриншоты)
<!--
Если ваш PR содержит внутриигровые изменения вы обязаны предоставить скриншоты/видео изменений.
-->

## Проверки

- [x] Я не требую помощи для завершения PR
- [x] Перед выкладыванием/запросом о рассмотрении PR, Я проверил работоспособность изменений.
- [x] Я добавил скриншоты/видео изменений, или данный PR не меняет внутриигровые механики

**Changelog**
<!--
Если нужно чтобы игроки узнали об изменениях сделаных в данном PR укажите их используя шаблон вне коментария. Кратко и информативно.

:cl: VigersRay
- add: Добавлено веселье.
- remove: Удалено веселье.
- tweak: Изменено веселье.
- fix: Исправлено веселье.
-->
