### PR TITLE
Фикс вечного выламывания дверей Scp096

### DIFF
--- a/Content.Server/_Scp/Scp096/Scp096System.cs
+++ b/Content.Server/_Scp/Scp096/Scp096System.cs
@@ -24,9 +24,15 @@ public sealed partial class Scp096System : SharedScp096System
         InitTargets();
     }
 
+    // TODO: Переделать это под отдельный компонент, который будет выдаваться и убираться
     protected override void HandleDoorCollision(Entity<Scp096Component> scpEntity, Entity<DoorComponent> doorEntity)
     {
         base.HandleDoorCollision(scpEntity, doorEntity);
+
+        if (!scpEntity.Comp.InRageMode)
+            return;
+
+        _doorSystem.StartOpening(doorEntity);
 
         if (TryComp<DoorBoltComponent>(doorEntity, out var doorBoltComponent))
         {

--- a/Content.Shared/_Scp/Scp096/SharedScp096System.cs
+++ b/Content.Shared/_Scp/Scp096/SharedScp096System.cs
@@ -370,13 +370,7 @@ public abstract partial class SharedScp096System : EntitySystem
         HandleDoorCollision(ent, new Entity<DoorComponent>(args.OtherEntity, doorComponent));
     }
 
-    protected virtual void HandleDoorCollision(Entity<Scp096Component> scpEntity, Entity<DoorComponent> doorEntity)
-    {
-        if (!scpEntity.Comp.InRageMode)
-            return;
-
-        _doorSystem.StartOpening(doorEntity);
-    }
+    protected virtual void HandleDoorCollision(Entity<Scp096Component> scpEntity, Entity<DoorComponent> doorEntity) {}
 
     #endregion
 

--- a/Resources/Prototypes/_Scp/Entities/Mobs/Player/scp096.yml
+++ b/Resources/Prototypes/_Scp/Entities/Mobs/Player/scp096.yml
@@ -111,10 +111,7 @@
   - type: Tag
     tags:
     - FootstepSound
-    - DoorBumpOpener
     - IgnorePortals
-  - type: TTS
-    voice: Neco
   - type: TypingIndicator
     proto: alien
   - type: Pacified


### PR DESCRIPTION
<!-- Пожалуйста прочитайте эту статью перед тем как выложить PR, чтобы избежать лишних правок в процессе осмотра: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- Текст в стрелочках является комментариями - они не будут видны в вашем PR. -->

## Кратное описание
<!-- Что вы предлагаете изменить с помощью своего PR? -->

Оказывается ретерн не ретернит в таком случае

Еще убрал дурбамопенер, потому что кринжик, что сцп может двери открывать сам по себе
А еще убрал ему неко ттс, какого хуя

## По какой причине
<!-- В чём причина добавления этих изменений? Ссылки на Дискуссии, а так-же Баг-Репорты указывать здесь. Пожалуйста опишите как это изменит игровой баланс. -->

![image](https://github.com/user-attachments/assets/42129934-c900-4ae8-8282-0aaaefe9f6e1)


## Медиа(Видео/Скриншоты)
<!--
Если ваш PR содержит внутриигровые изменения вы обязаны предоставить скриншоты/видео изменений.
-->

## Проверки

- [ ] Я не требую помощи для завершения PR
- [ ] Перед выкладыванием/запросом о рассмотрении PR, Я проверил работоспособность изменений.
- [ ] Я добавил скриншоты/видео изменений, или данный PR не меняет внутриигровые механики

**Changelog**
<!--
Если нужно чтобы игроки узнали об изменениях сделаных в данном PR укажите их используя шаблон вне коментария. Кратко и информативно.

:cl: VigersRay
- add: Добавлено веселье.
- remove: Удалено веселье.
- tweak: Изменено веселье.
- fix: Исправлено веселье.
-->
