### PR TITLE
Апдейт карты и связанные с ней вещи

### DIFF
--- a/Resources/Prototypes/GameRules/roundstart.yml
+++ b/Resources/Prototypes/GameRules/roundstart.yml
@@ -309,6 +309,10 @@
     children:
       - !type:NestedSelector
         tableId: BasicCalmEventsTable
+      # Fire edit start
+      - !type:NestedSelector
+        tableId: ScpEventsTable
+      # Fire edit end
       - !type:NestedSelector
         tableId: BasicAntagEventsTable
       - !type:NestedSelector

--- a/Resources/Prototypes/_Scp/GameRules/events.yml
+++ b/Resources/Prototypes/_Scp/GameRules/events.yml
@@ -12,4 +12,4 @@
   id: ScpEventsTable
   table: !type:AllSelector
     children:
-    - id: Blackout # TODO: Создать свою таблицу ивентов
+    - id: Blackout

--- a/Resources/Prototypes/_Scp/Maps/scpcomplex.yml
+++ b/Resources/Prototypes/_Scp/Maps/scpcomplex.yml
@@ -22,6 +22,7 @@
             ClassD: [ 1, 1 ]
             ClassDCook: [ 2, 2 ]
             ClassDBotanist: [ 2, 2 ]
+            ClassDJanitor: [ 1, 1 ]
             #scp
             Scp049: [ 1, 1 ]
             Scp096: [ 1, 1 ]


### PR DESCRIPTION
<!-- Пожалуйста прочитайте эту статью перед тем как выложить PR, чтобы избежать лишних правок в процессе осмотра: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- Текст в стрелочках является комментариями - они не будут видны в вашем PR. -->

## Кратное описание
<!-- Что вы предлагаете изменить с помощью своего PR? -->

Блекаут был добавлен тут, но нужно было замаппить рычаг для перезапуска питания, прежде чем пускать его в продакшен

- [x]  #169

## Сссылка на багрепорт/ТЗ/Предложение
<!-- В чём причина добавления этих изменений? Ссылки на Дискуссии, а так-же Баг-Репорты указывать здесь. Пожалуйста опишите как это изменит игровой баланс. -->

## Медиа(Видео/Скриншоты)
<!--
Если ваш PR содержит внутриигровые изменения вы обязаны предоставить скриншоты/видео изменений.
-->

<!--
## TODO

Не закончили? Добавьте список того, что требуется для завершения PR`а
-->

**Changelog**

:cl: ThereDrD
- add: Обновлена карта комплекса, пофикшены некоторые баги, убраны 5 каплей статиса с 173
- add: Добавлен на карту уборщик класса Д. Теперь за него можно играть
- add: Добавлен новый ивент - блекаут. Он является переработанным отключением света. В отличие от своих аналогов он отключает свет и НЕ дает переключить апц вручную. Чтобы восстановить свет нужно прийти к инженерный отдел и дернуть за перезапускающий электропитание рычаг, который находится рядом со СМЕСами.

