### PR TITLE
Фиксы и пара твиков

### DIFF
--- a/Content.Client/_Scp/Audio/AudioMuffleSystem.cs
+++ b/Content.Client/_Scp/Audio/AudioMuffleSystem.cs
@@ -24,7 +24,17 @@ public sealed class AudioMuffleSystem : EntitySystem
     [Dependency] private readonly IConfigurationManager _cfg = default!;
 
     private static readonly ProtoId<AudioPresetPrototype> MufflingEffectPreset = "ScpBehindWalls";
-    private static readonly HashSet<ProtoId<TagPrototype>> SoundproofingTags = ["Wall", "Window", "Airlock", "GlassAirlock"];
+    private static readonly HashSet<ProtoId<TagPrototype>> SoundproofingTags =
+    [
+        "Wall",
+        "Window",
+        "Airlock",
+        "GlassAirlock",
+        "Windoor",
+        "SecureWindoor",
+        "SecurePlasmaWindoor",
+        "SecureUraniumWindoor",
+    ];
 
     private const float ReducedVolume = -20f;
     private const float HearRange = 14f;

--- a/Content.Client/_Scp/Shaders/Common/Grain/GrainOverlay.cs
+++ b/Content.Client/_Scp/Shaders/Common/Grain/GrainOverlay.cs
@@ -1,4 +1,5 @@
 ﻿using Robust.Client.Graphics;
+using Robust.Client.Player;
 using Robust.Shared.Enums;
 using Robust.Shared.Prototypes;
 
@@ -10,6 +11,10 @@ namespace Content.Client._Scp.Shaders.Common.Grain;
 public sealed class GrainOverlay : Overlay
 {
     [Dependency] private readonly IPrototypeManager _prototype = default!;
+    [Dependency] private readonly IPlayerManager _player = default!;
+    [Dependency] private readonly IEntityManager _entManager = default!;
+
+    private readonly EntityQuery<EyeComponent> _eyeQuery;
 
     private readonly ShaderInstance _shader;
 
@@ -22,6 +27,8 @@ public sealed class GrainOverlay : Overlay
     {
         IoCManager.InjectDependencies(this);
 
+        _eyeQuery = _entManager.GetEntityQuery<EyeComponent>();
+
         _shader = _prototype.Index<ShaderPrototype>("Grain").InstanceUnique();
     }
 
@@ -32,6 +39,11 @@ public sealed class GrainOverlay : Overlay
     protected override bool BeforeDraw(in OverlayDrawArgs args)
     {
         if (CurrentStrength == 0f)
+            return false;
+
+        var playerEntity = _player.LocalEntity;
+
+        if (!_eyeQuery.TryGetComponent(playerEntity, out var eyeComp) || args.Viewport.Eye != eyeComp.Eye)
             return false;
 
         return true;

--- a/Content.Client/_Scp/Shaders/Common/Vignette/VignetteOverlay.cs
+++ b/Content.Client/_Scp/Shaders/Common/Vignette/VignetteOverlay.cs
@@ -1,4 +1,5 @@
 ﻿using Robust.Client.Graphics;
+using Robust.Client.Player;
 using Robust.Shared.Enums;
 using Robust.Shared.Prototypes;
 
@@ -7,6 +8,10 @@ namespace Content.Client._Scp.Shaders.Common.Vignette;
 public sealed class VignetteOverlay : Overlay
 {
     [Dependency] private readonly IPrototypeManager _prototype = default!;
+    [Dependency] private readonly IPlayerManager _player = default!;
+    [Dependency] private readonly IEntityManager _entManager = default!;
+
+    private readonly EntityQuery<EyeComponent> _eyeQuery;
 
     private readonly ShaderInstance _shader;
 
@@ -16,7 +21,9 @@ public sealed class VignetteOverlay : Overlay
     {
         IoCManager.InjectDependencies(this);
 
-        _shader = _prototype.Index<ShaderPrototype>("Vignette").Instance().Duplicate();
+        _eyeQuery = _entManager.GetEntityQuery<EyeComponent>();
+
+        _shader = _prototype.Index<ShaderPrototype>("Vignette").InstanceUnique();
     }
 
     public override OverlaySpace Space => OverlaySpace.WorldSpace;
@@ -26,6 +33,11 @@ public sealed class VignetteOverlay : Overlay
     protected override bool BeforeDraw(in OverlayDrawArgs args)
     {
         if (CurrentStrength == 0)
+            return false;
+
+        var playerEntity = _player.LocalEntity;
+
+        if (!_eyeQuery.TryGetComponent(playerEntity, out var eyeComp) || args.Viewport.Eye != eyeComp.Eye)
             return false;
 
         return true;

--- a/Content.Server/_Scp/GameTicking/Rules/AirlockManEater/AirlockManEaterRule.cs
+++ b/Content.Server/_Scp/GameTicking/Rules/AirlockManEater/AirlockManEaterRule.cs
@@ -18,8 +18,13 @@ public sealed class AirlockManEaterRule : StationEventSystem<AirlockManEaterRule
     [Dependency] private readonly StationSystem _station = default!;
     [Dependency] private readonly IRobustRandom _random = default!;
 
-    private static readonly ProtoId<TagPrototype> WindoorTag = "Windoor";
-    private static readonly ProtoId<TagPrototype> SecureWindoorTag = "SecureWindoor";
+    private static readonly List<ProtoId<TagPrototype>> BlacklistedTags =
+    [
+        "Windoor",
+        "SecureWindoor",
+        "SecurePlasmaWindoor",
+        "SecureUraniumWindoor",
+    ];
 
     protected override void Started(EntityUid uid, AirlockManEaterRuleComponent component, GameRuleComponent gameRule, GameRuleStartedEvent args)
     {
@@ -55,7 +60,7 @@ public sealed class AirlockManEaterRule : StationEventSystem<AirlockManEaterRule
         if (_station.GetOwningStation(ent) != station)
             return false;
 
-        if (_tag.HasTag(ent, WindoorTag) || _tag.HasTag(ent, SecureWindoorTag))
+        if (_tag.HasAnyTag(ent, BlacklistedTags))
             return false;
 
         return true;

--- a/Resources/Prototypes/GameRules/events.yml
+++ b/Resources/Prototypes/GameRules/events.yml
@@ -348,14 +348,11 @@
   id: GasLeak
   parent: BaseStationEventShortDelay
   components:
+  # Fire edit - убрал звуки аннонсментов
   - type: StationEvent
     startAnnouncement: station-event-gas-leak-start-announcement
-    startAudio:
-      path: /Audio/_Sunrise/Announcements/announce_dig.ogg # Sunrise-edit
     endAnnouncement: station-event-gas-leak-end-announcement
     weight: 8
-    endAudio:
-      path: /Audio/_Sunrise/Announcements/announce_dig.ogg # Sunrise-edit
   - type: GasLeakRule
 
 - type: entity
@@ -389,10 +386,12 @@
   components:
   - type: StationEvent
     weight: 8
-    startAnnouncement: station-event-solar-flare-start-announcement
-    endAnnouncement: station-event-solar-flare-end-announcement
+    # Fire edit start - оповещение нахуй, звук поменял
     startAudio:
-      path: /Audio/_Sunrise/Announcements/announce_dig.ogg # Sunrise-edit
+      path: /Audio/_Sunrise/Announcements/ionstorm.ogg
+      params:
+        volume: -10
+    # Fire edit end
     duration: 120
     maxDuration: 240
   - type: SolarFlareRule

--- a/Resources/Prototypes/GameRules/roundstart.yml
+++ b/Resources/Prototypes/GameRules/roundstart.yml
@@ -425,9 +425,9 @@
   id: BasicGameRulesTable
   table: !type:AllSelector # we need to pass a list of rules, since rules have further restrictions to consider via StationEventComp
     children:
-      - !type:NestedSelector
-        tableId: BasicCalmEventsTable
       # Fire edit start
+      - !type:NestedSelector
+        tableId: ScpVanillaEventsTable
       - !type:NestedSelector
         tableId: ScpEventsTable
       # Fire edit end

--- a/Resources/Prototypes/_Scp/Entities/Mobs/Player/Scp/Main/scp049.yml
+++ b/Resources/Prototypes/_Scp/Entities/Mobs/Player/Scp/Main/scp049.yml
@@ -45,6 +45,7 @@
   - type: ComplexInteraction
   - type: Buckle
   - type: Stripping
+  - type: StandingState
   - type: Pacified
   - type: UserInterface
     interfaces:
@@ -58,12 +59,12 @@
   - type: MobThresholds
     thresholds:
       0: Alive
-      2000: Critical
+      500: Critical
   - type: SlowOnDamage
     speedModifierThresholds:
-      1000: 0.9
-      1500: 0.8
-      2000: 0.7
+      100: 0.9
+      250: 0.8
+      400: 0.7
   - type: Pullable
   - type: Puller
     needsHands: true

--- a/Resources/Prototypes/_Scp/GameRules/events.yml
+++ b/Resources/Prototypes/_Scp/GameRules/events.yml
@@ -13,7 +13,7 @@
   parent: BaseStationEventShortDelay
   components:
   - type: StationEvent
-    weight: 10
+    weight: 2
     duration: 60
     maxDuration: 120
   - type: BlackoutRule
@@ -23,9 +23,9 @@
   parent: BaseStationEventShortDelay
   components:
   - type: StationEvent
-    weight: 6
+    weight: 2
   - type: SpawnRandomEntitiesRule
-    tilesPerEntityAverage: 400
+    tilesPerEntityAverage: 600
     entities:
     - id: Scp096PhotoDeveloped
 
@@ -34,8 +34,26 @@
   parent: BaseStationEventZeroDelay
   components:
   - type: StationEvent
-    weight: 10
+    weight: 1
   - type: AirlockManEaterRule
+
+- type: entityTable
+  id: ScpVanillaEventsTable
+  table: !type:AllSelector
+    children:
+    - id: BluespaceArtifact
+    - id: BureaucraticError
+    - id: ClericalError
+    - id: CockroachMigration
+    - id: GasLeak
+    - id: GreytideVirus
+    - id: IonStorm
+    - id: MassHallucinations
+    - id: MimicVendorRule
+    - id: MouseMigration
+    - id: RandomSentience
+    - id: SolarFlare
+    - id: VentClog
 
 - type: entityTable
   id: ScpEventsTable

--- a/Resources/Prototypes/_Scp/GameRules/events.yml
+++ b/Resources/Prototypes/_Scp/GameRules/events.yml
@@ -13,7 +13,7 @@
   parent: BaseStationEventShortDelay
   components:
   - type: StationEvent
-    weight: 2
+    weight: 5
     duration: 60
     maxDuration: 120
   - type: BlackoutRule
@@ -23,7 +23,7 @@
   parent: BaseStationEventShortDelay
   components:
   - type: StationEvent
-    weight: 2
+    weight: 3
   - type: SpawnRandomEntitiesRule
     tilesPerEntityAverage: 600
     entities:

--- a/Resources/Prototypes/_Sunrise/Entities/Mobs/Customization/Markings/fox_parts.yml
+++ b/Resources/Prototypes/_Sunrise/Entities/Mobs/Customization/Markings/fox_parts.yml
@@ -2,7 +2,7 @@
   id: FoxEars
   bodyPart: HeadTop
   markingCategory: HeadTop
-  speciesRestriction: [Human]
+  speciesRestriction: [Felinid] # Fire edit - опять насрали своими ушками
   sponsorOnly: false
   sprites:
   - sprite: _Sunrise/Mobs/Customization/fox_parts.rsi

--- a/Resources/Prototypes/_Sunrise/Traits/quirks.yml
+++ b/Resources/Prototypes/_Sunrise/Traits/quirks.yml
@@ -6,15 +6,5 @@
   components:
   - type: NoEmotions
 
-- type: trait
-  id: FelinidVocal
-  name: trait-felinid-vocal-name
-  description: trait-felinid-vocal-desc
-  category: VocalTraits
-  cost: 1
-  components:
-  - type: ReplacementVocal
-    vocal:
-      Male: MaleFelinid
-      Female: FemaleFelinid
-      Unsexed: MaleFelinid
+# Фак ю
+# Здесь было мурлыкание, но я его удалил


### PR DESCRIPTION
<!-- Текст в стрелочках является комментариями - они не будут видны в вашем PR. -->

## Краткое описание
<!-- Что вы предлагаете изменить с помощью своего PR? -->

## Сссылка на багрепорт/ТЗ/Предложение
<!-- В чём причина добавления этих изменений? Ссылки на Дискуссии, а так-же Баг-Репорты указывать здесь. Пожалуйста опишите как это изменит игровой баланс. -->

## Медиа(Видео/Скриншоты)
<!--
Если ваш PR содержит внутриигровые изменения вы обязаны предоставить скриншоты/видео изменений.
-->

<!--
## TODO

Не закончили? Добавьте список того, что требуется для завершения PR`а
-->

**Changelog**

<!--
КАК ПИСАТЬ ЧЕЙНЖЛОГ:

1) Не считайте тип чейнжлога частью вашего предложения. Так не принято. То есть:
add: Новая фича = ПЛОХО
add: Добавлена новая фича = ХОРОШО

2) Подробно описывайте, что вы добавили и как это использовать/найти. Главное не переусердствуйте. Все должно быть в меру

fix: Исправлены мелочи = УЖАСНО
fix: Исправлены некоторые баги в коде сцп 173 = ПЛОХО
fix: Исправлена невозможность сцп173 двигаться = ХОРОШО

3) Не добавляйте в чейнжлог технические детали вашего изменения. Чейнжлог для игроков, пишите его для игроков. Им не нужно знать технические детали

add: Добавлен новый хелпер-метод в систему сцп106 = ПЛОХО
НИЧЕГО НЕ ПИСАТЬ = ХОРОШО.

Иногда чейнжог не нужен. Просто удалите это поле

-->

:cl: ThereDrD
- tweak: Сильно порезано здоровье SCP-049. Теперь вместо 2000 очков здоровья он имеет 500. Он не должен был быть таким толстым, так как сам по себе является слабым объектом с уклоном в разговоры, а также имеет абилка на полный отхил себя.
- tweak: Изменен баланс весов случайных ивентов. Шлюзов людоедов теперь должно стать меньше
- tweak: В ротацию ивентов добавлена утечка газа и выключение радиочастоты.
- fix: SCP-049 теперь может ложиться и вставать самостоятельно
- fix: Виньетка и зернистость теперь не появляются в шахматах, консоли камер и других интерфейсах.
- fix: Раздвижные двери теперь точно не могут убивать
- fix: Раздвижные двери теперь заглушают звуки
- remove: Убран трейт на мурлыканье и лисьи ушки у людей



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Новые возможности**
  * Добавлена новая таблица событий ScpVanillaEventsTable с расширенным списком событий.
  * Для SCP-049 добавлен компонент StandingState.

* **Исправления ошибок**
  * Расширен список объектов, блокирующих звук, для более корректного приглушения аудио.
  * Исправлена логика фильтрации сущностей для события AirlockManEater.

* **Изменения баланса**
  * Снижены веса событий Blackout, SpawnScp096Photo и AirlockManEater.
  * Для SpawnScp096Photo увеличен параметр tilesPerEntityAverage.
  * Пороги повреждений и замедления SCP-049 снижены, что влияет на его поведение при получении урона.

* **Изменения интерфейса и визуальных эффектов**
  * Эффекты GrainOverlay и VignetteOverlay теперь отображаются только при совпадении взгляда игрока с вьюпортом.

* **Обновление аудиовизуальных уведомлений**
  * Для событий GasLeak и SolarFlare изменены или удалены звуковые и текстовые уведомления.

* **Обновления кастомизации**
  * Маркировка FoxEars теперь доступна только для Felinid, а не для людей.

* **Удаления**
  * Удалена черта FelinidVocal (замена вокала для фелинидов).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->