### PR TITLE
Обновление сырья для амнезиака

### DIFF
--- a/Resources/Prototypes/_Scp/Reagents/amnesiac.yml
+++ b/Resources/Prototypes/_Scp/Reagents/amnesiac.yml
@@ -155,7 +155,50 @@
   color: "#383e28"
   physicalDesc: reagent-physical-desc-exotic-smelling
   metabolisms:
+    Poison:
+      metabolismRate: 100
+      effects:
+      - !type:PopupMessage
+        type: Local
+        visualType: MediumCaution
+        messages: [ reagent-amnesiac-a-msg ]
+        probability: 1
+        conditions:
+        - !type:ReagentThreshold
+          reagent: RawAmnesiac
+          min: 5
+          max: 9
+      - !type:PopupMessage
+        type: Local
+        visualType: MediumCaution
+        messages: [ reagent-amnesiac-b-msg ]
+        probability: 1
+        conditions:
+        - !type:ReagentThreshold
+          reagent: RawAmnesiac
+          min: 10
+          max: 14
+      - !type:PopupMessage
+        type: Local
+        visualType: MediumCaution
+        messages: [ reagent-amnesiac-c-msg ]
+        probability: 1
+        conditions:
+        - !type:ReagentThreshold
+          reagent: RawAmnesiac
+          min: 15
+          max: 19
+      - !type:PopupMessage
+        type: Local
+        visualType: MediumCaution
+        messages: [ reagent-amnesiac-d-msg ]
+        probability: 1
+        conditions:
+        - !type:ReagentThreshold
+          reagent: RawAmnesiac
+          min: 20
     Narcotic:
+      metabolismRate: 100
       effects:
       - !type:GenericStatusEffect
         conditions:


### PR DESCRIPTION
## Краткое описание
Обновление сырья для амнезиака

:cl: Wardex
- tweak: Сырьё для амнезиака теперь опасно для питья.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Новые возможности**
  * Добавлены новые предупреждающие сообщения при различных уровнях количества реагента RawAmnesiac.
* **Изменения**
  * Обновлены параметры метаболизма для реагента RawAmnesiac.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->