### PR TITLE
Исправление опечатки

### DIFF
--- a/Content.Shared/_Scp/Scp096/SharedScp096System.cs
+++ b/Content.Shared/_Scp/Scp096/SharedScp096System.cs
@@ -126,7 +126,7 @@ public abstract partial class SharedScp096System : EntitySystem
 
     private void OnPacifiedAttackAttempt(Entity<Scp096Component> ent, ref AttemptPacifiedAttackEvent args)
     {
-        args.Reason = Loc.GetString("scp096-non-argo-attack-attempt");
+        args.Reason = Loc.GetString("scp096-non-agro-attack-attempt");
         args.Cancelled = true;
     }
 

--- a/Resources/Locale/en-US/_strings/_scp/scp/scp096.ftl
+++ b/Resources/Locale/en-US/_strings/_scp/scp/scp096.ftl
@@ -1,4 +1,4 @@
-scp096-non-argo-attack-attempt = I don't want to do this
+scp096-non-agro-attack-attempt = I don't want to do this
 
 scp096-targets-left-label = Remaining: { $targets } {$targets ->
         [one] target

--- a/Resources/Locale/ru-RU/_strings/_scp/scp/scp096.ftl
+++ b/Resources/Locale/ru-RU/_strings/_scp/scp/scp096.ftl
@@ -1,7 +1,7 @@
 scp-mask-cannot-equip = Маска слишком велика для { $name }
 scp-mask-cannot-tear-safetime = Вы не можете снять маску сейчас. Оставшее время до возможного снятия: { $time }
 scp-destroyed-mask = { $scp } разрывает { $mask }
-scp096-non-argo-attack-attempt = Я не хочу этого делать
+scp096-non-agro-attack-attempt = Я не хочу этого делать
 scp096-targets-left-label =
     Осталось: { $targets } { $targets ->
         [one] цель


### PR DESCRIPTION
## Краткое описание
Исправление опечатки

:cl: Wardex
- fix: Исправлено опечатку в переводе.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Исправления ошибок**
  * Исправлена опечатка в ключе локализации для сообщения при попытке атаки в состоянии умиротворения SCP-096 на русском и английском языках.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->