### PR TITLE
Удаление рикошета стен

### DIFF
--- a/Resources/Prototypes/Entities/Structures/Walls/walls.yml
+++ b/Resources/Prototypes/Entities/Structures/Walls/walls.yml
@@ -852,8 +852,8 @@
   - type: Icon
     sprite: Structures/Walls/shuttle_diagonal.rsi
     state: state0
-  - type: Reflect
-    reflectProb: 1
+  # - type: Reflect #Fire Edit
+  #   reflectProb: 1
   - type: Pullable
   - type: Airtight
     noAirWhenFullyAirBlocked: false
@@ -964,8 +964,8 @@
           3: { state: shuttle_construct-3, visible: true}
           4: { state: shuttle_construct-4, visible: true}
           5: { state: shuttle_construct-5, visible: true}
-  - type: Reflect
-    reflectProb: 1
+  # - type: Reflect #Fire Edit
+  #   reflectProb: 1
   - type: Fixtures
     fixtures:
       fix1:


### PR DESCRIPTION
## Краткое описание
Снёс к хуям рефлект у диагональных стен (В добавок и у белых).
Пример херни которая ранее была на скринах ниже:

## Медиа(Видео/Скриншоты)
2 выстрела, и оба отрикошетило на ~180 градусов.
<img width="356" height="348" alt="image" src="https://github.com/user-attachments/assets/de73b404-4663-4a48-831e-ae91f71c5c6d" />

**Changelog**
:cl: Parashut
- remove: Удалено отражение у диагональных стен. Теперь вы не убьёте себя случайно во время перестрелки.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Изменения**
  * В стенах шаттла отключено отражение (Reflect) для некоторых вариантов стен.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->