### PR TITLE
Правка коллизии Атмосферы окон

### DIFF
--- a/Resources/Prototypes/_Scp/Entities/Structures/Windows/window.yml
+++ b/Resources/Prototypes/_Scp/Entities/Structures/Windows/window.yml
@@ -40,7 +40,7 @@
         - FullTileMask
         layer:
         - GlassLayer
-  - type: Airtight #Fire Edit
+  - type: Airtight
     noAirWhenFullyAirBlocked: false
     airBlockedDirection:
     - South
@@ -84,7 +84,7 @@
         - FullTileMask
         layer:
         - GlassLayer
-  - type: Airtight #Fire Edit
+  - type: Airtight
     noAirWhenFullyAirBlocked: false
     airBlockedDirection:
     - South

--- a/Resources/Prototypes/_Scp/Entities/Structures/Windows/window.yml
+++ b/Resources/Prototypes/_Scp/Entities/Structures/Windows/window.yml
@@ -40,6 +40,11 @@
         - FullTileMask
         layer:
         - GlassLayer
+  - type: Airtight #Fire Edit
+    noAirWhenFullyAirBlocked: false
+    airBlockedDirection:
+    - South
+    - East
 
 - type: entity
   id: BaseScpWindowDirectionalRound
@@ -79,6 +84,12 @@
         - FullTileMask
         layer:
         - GlassLayer
+  - type: Airtight #Fire Edit
+    noAirWhenFullyAirBlocked: false
+    airBlockedDirection:
+    - South
+    - East
+    - West
 
 - type: entity
   parent: Window


### PR DESCRIPTION
## Краткое описание
Поправил компонент Airtight у угловых окон.

## Медиа(Видео/Скриншоты)
**Ориг:**
<img width="767" height="251" alt="image" src="https://github.com/user-attachments/assets/e4c59514-1640-47c1-a59e-006d5a8d4eff" />

**Было:**
<img width="764" height="251" alt="image" src="https://github.com/user-attachments/assets/45ac2228-b1f9-41b9-a2d1-fa3ad39bf75d" />

**Стало:**
<img width="765" height="251" alt="image" src="https://github.com/user-attachments/assets/19083be5-7995-44d4-ada4-9fa4ccd8efbd" />


**Changelog**
:cl: Parashut
- fix: Исправлена коллизия атмоса у угловых стеклянных панелей.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Новые возможности**
  * Улучшена герметичность некоторых типов окон: теперь окна определённых форм блокируют поток воздуха с определённых направлений.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->