### PR TITLE
Таймеры открытия SCP ролей.

### DIFF
--- a/Resources/Prototypes/_Scp/Roles/Jobs/SCP/AllSCP.yml
+++ b/Resources/Prototypes/_Scp/Roles/Jobs/SCP/AllSCP.yml
@@ -73,7 +73,7 @@
   playTimeTracker: JobScp096
   requirements:
   - !type:OverallPlaytimeRequirement
-    time: 1080000 # 200h
+    time: 720000 # 200h
   weight: 25
   icon: JobIconScp096
   joinNotifyCrew: false


### PR DESCRIPTION
## Краткое описание
Изменены временные шкалы для открытия SCP ролей.

- Save - 100 часов общего времени.
- Euclid - 200 часов общего времени.
- Keter - 300 часов общего времени.

**Changelog**
:cl: Parashut
- tweak: Изменено требуемое кол-во общего игрового времени для открытия SCP ролей. Теперь все SCP роли имеют своё требование по часам, а не 200 как было раньше (Безопасный - 100 часов/Евклид - 200 часов/Кетер - 300 часов).



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Обновлены пороги общего времени игры для ряда SCP-ролей:
    - SCP-939: с 200 до 300 часов
    - SCP-999: с 200 до 100 часов
    - SCP-106: с 200 до 300 часов
  * Эти изменения влияют на доступность соответствующих ролей в зависимости от суммарного времени, проведённого в игре.
  * Прочие параметры ролей не изменялись; обновление применяется автоматически и не требует действий со стороны пользователей.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->