### PR TITLE
Удаление кубиков из ассортимента логистического отдела

### DIFF
--- a/Resources/Prototypes/Catalog/Cargo/cargo_livestock.yml
+++ b/Resources/Prototypes/Catalog/Cargo/cargo_livestock.yml
@@ -118,6 +118,8 @@
   category: cargoproduct-category-name-livestock
   group: market
 
+# Fire Edit > start
+
 #- type: cargoProduct
 #  id: LivestockMonkeyCube
 #  icon:
@@ -137,6 +139,8 @@
 #  cost: 2000
 #  category: cargoproduct-category-name-livestock
 #  group: market
+
+# Fire Edit > end
 
 - type: cargoProduct
   id: LivestockMouse

--- a/Resources/Prototypes/Catalog/Cargo/cargo_livestock.yml
+++ b/Resources/Prototypes/Catalog/Cargo/cargo_livestock.yml
@@ -118,25 +118,25 @@
   category: cargoproduct-category-name-livestock
   group: market
 
-- type: cargoProduct
-  id: LivestockMonkeyCube
-  icon:
-    sprite: Objects/Misc/monkeycube.rsi
-    state: box
-  product: CrateNPCMonkeyCube
-  cost: 2000
-  category: cargoproduct-category-name-livestock
-  group: market
+#- type: cargoProduct
+#  id: LivestockMonkeyCube
+#  icon:
+#    sprite: Objects/Misc/monkeycube.rsi
+#    state: box
+#  product: CrateNPCMonkeyCube
+#  cost: 2000
+#  category: cargoproduct-category-name-livestock
+#  group: market
 
-- type: cargoProduct
-  id: LivestockKoboldCube
-  icon:
-    sprite: Objects/Misc/monkeycube.rsi
-    state: box_kobold
-  product: CrateNPCKoboldCube
-  cost: 2000
-  category: cargoproduct-category-name-livestock
-  group: market
+#- type: cargoProduct
+#  id: LivestockKoboldCube
+#  icon:
+#    sprite: Objects/Misc/monkeycube.rsi
+#    state: box_kobold
+#  product: CrateNPCKoboldCube
+#  cost: 2000
+#  category: cargoproduct-category-name-livestock
+#  group: market
 
 - type: cargoProduct
   id: LivestockMouse

--- a/Resources/Prototypes/_Sunrise/Catalog/Cargo/cargo_medical.yml
+++ b/Resources/Prototypes/_Sunrise/Catalog/Cargo/cargo_medical.yml
@@ -1,3 +1,5 @@
+#Fire Edit > start
+
 #- type: cargoProduct
 #  id: CrateNPCVariantCubeBoxSunrise
 #  icon:
@@ -7,3 +9,5 @@
 #  cost: 12000
 #  category: cargoproduct-category-name-medical
 #  group: market
+
+# Fire Edit > end

--- a/Resources/Prototypes/_Sunrise/Catalog/Cargo/cargo_medical.yml
+++ b/Resources/Prototypes/_Sunrise/Catalog/Cargo/cargo_medical.yml
@@ -1,9 +1,9 @@
-- type: cargoProduct
-  id: CrateNPCVariantCubeBoxSunrise
-  icon:
-    sprite: Objects/Misc/monkeycube.rsi
-    state: box_variant
-  product: CrateNPCVariantCubeBoxSunrise
-  cost: 12000
-  category: cargoproduct-category-name-medical
-  group: market
+#- type: cargoProduct
+#  id: CrateNPCVariantCubeBoxSunrise
+#  icon:
+#    sprite: Objects/Misc/monkeycube.rsi
+#    state: box_variant
+#  product: CrateNPCVariantCubeBoxSunrise
+#  cost: 12000
+#  category: cargoproduct-category-name-medical
+#  group: market


### PR DESCRIPTION
## Краткое описание
Удаление кубиков кобольдов, макак и феленидов из ассортимента логистического отдела.

:cl: Wardex
- remove: Удалено кубики кобольдов, макак и феленидов из ассортимента логистического отдела.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* Изменения
  * Отключены отдельные позиции в каталоге грузов: «Куб-монка» и «Куб-кобольда» (живой товар), а также медицинский «Вариантный куб (Sunrise)».
  * Эти товары больше недоступны для заказа через карго.

* Chores
  * Очистка каталога: временное исключение вышеуказанных позиций без добавления новых альтернатив.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->