### PR TITLE
Наборы пополнения Д класса

### DIFF
--- a/Resources/Locale/ru-RU/_prototypes/_scp/catalog/fills/crates/vending.ftl
+++ b/Resources/Locale/ru-RU/_prototypes/_scp/catalog/fills/crates/vending.ftl
@@ -1,0 +1,10 @@
+ent-CrateVendingMachineRestockSeedsScpClassDFilled = ящик пополнения { ent-VendingMachineSeedsDClass } D класса
+    .desc = Содержит набор пополнения торгомата { ent-VendingMachineSeedsDClass }.
+ent-CrateVendingMachineRestockNutriMaxScpClassDFilled = ящик пополнения { ent-VendingMachineNutriDClass } D класса
+    .desc = Содержит набор пополнения торгомата { ent-VendingMachineNutriDClass }.
+ent-CrateVendingMachineRestockChefvendScpClassDFilled = ящик пополнения { ent-VendingMachineChefvendDClass } D класса
+    .desc = Содержит набор пополнения торгомата { ent-VendingMachineChefvendDClass }.
+ent-CrateVendingMachineRestockDinnerwareScpClassDFilled = ящик пополнения { ent-VendingMachineDinnerwareDClass } D класса
+    .desc = Содержит набор пополнения торгомата { ent-VendingMachineDinnerwareDClass }.
+ent-CrateVendingMachineRestockBoozeScpClassDFilled = ящик пополнения { ent-VendingMachineBoozeDClass } D класса
+    .desc = Содержит набор пополнения торгомата { ent-VendingMachineBoozeDClass }.

--- a/Resources/Locale/ru-RU/_prototypes/_scp/entities/objects/specific/service/vending_machine_restock.ftl
+++ b/Resources/Locale/ru-RU/_prototypes/_scp/entities/objects/specific/service/vending_machine_restock.ftl
@@ -1,0 +1,10 @@
+ent-VendingMachineRestockSeedsScpClassD = набор пополнения { ent-VendingMachineSeedsDClass } D класса
+    .desc = На этикетке написано, что этими семенами пользовались и передавали по наследству ещё наши предки. Загрузите их в { ent-VendingMachineSeedsDClass }!
+ent-VendingMachineRestockNutriMaxScpClassD = набор пополнения { ent-VendingMachineNutriDClass } D класса
+    .desc = С нашими удобрениями ваши золотые руки станут зелёными! Пора пожинать плоды! Загрузите в автомат { ent-VendingMachineNutriDClass }.
+ent-VendingMachineRestockChefvendScpClassD = набор пополнения { ent-VendingMachineChefvendDClass } D класса
+    .desc = Пополняет { ent-VendingMachineChefvendDClass }. Главное, берегите яйца.
+ent-VendingMachineRestockDinnerwareScpClassD = набор пополнения { ent-VendingMachineDinnerwareDClass } D класса
+    .desc = На этой кухне всегда жарко! Поместите в слот для пополнения { ent-VendingMachineDinnerwareDClass }, чтобы начать.
+ent-VendingMachineRestockBoozeScpClassD = набор пополнения { ent-VendingMachineBoozeDClass } D класса
+    .desc = Поместите в { ent-VendingMachineBoozeDClass } чтобы напоить жаждущих! Не для продажи персоналу.

--- a/Resources/Prototypes/Entities/Objects/Specific/Service/vending_machine_restock.yml
+++ b/Resources/Prototypes/Entities/Objects/Specific/Service/vending_machine_restock.yml
@@ -135,6 +135,7 @@
     - ViroDrobeInventory
     - WinterDrobeInventory
     - CuraDrobeInventory
+    - ChefDrobeInventoryDClass # Fire Edit
   - type: Sprite
     layers:
     - state: base

--- a/Resources/Prototypes/_Scp/Catalog/Cargo/cargo_vending.yml
+++ b/Resources/Prototypes/_Scp/Catalog/Cargo/cargo_vending.yml
@@ -1,0 +1,49 @@
+- type: cargoProduct
+  id: CrateVendingMachineRestockSeedsScpClassD
+  icon:
+    sprite: Objects/Specific/Service/vending_machine_restock.rsi
+    state: base
+  product: CrateVendingMachineRestockSeedsScpClassDFilled
+  cost: 1000
+  category: cargoproduct-category-name-service
+  group: market
+
+- type: cargoProduct
+  id: CrateVendingMachineRestockNutriMaxScpClassD
+  icon:
+    sprite: Objects/Specific/Service/vending_machine_restock.rsi
+    state: base
+  product: CrateVendingMachineRestockNutriMaxScpClassDFilled
+  cost: 600
+  category: cargoproduct-category-name-service
+  group: market
+
+- type: cargoProduct
+  id: CrateVendingMachineRestockChefvendScpClassD
+  icon:
+    sprite: Objects/Specific/Service/vending_machine_restock.rsi
+    state: base
+  product: CrateVendingMachineRestockChefvendScpClassDFilled
+  cost: 800
+  category: cargoproduct-category-name-service
+  group: market
+
+- type: cargoProduct
+  id: CrateVendingMachineRestockDinnerwareScpClassD
+  icon:
+    sprite: Objects/Specific/Service/vending_machine_restock.rsi
+    state: base
+  product: CrateVendingMachineRestockDinnerwareScpClassDFilled
+  cost: 400
+  category: cargoproduct-category-name-service
+  group: market
+
+- type: cargoProduct
+  id: CrateVendingMachineRestockBoozeScpClassD
+  icon:
+    sprite: Objects/Specific/Service/vending_machine_restock.rsi
+    state: base
+  product: CrateVendingMachineRestockBoozeScpClassDFilled
+  cost: 600
+  category: cargoproduct-category-name-service
+  group: market

--- a/Resources/Prototypes/_Scp/Catalog/Fills/Crates/vending.yml
+++ b/Resources/Prototypes/_Scp/Catalog/Fills/Crates/vending.yml
@@ -1,0 +1,49 @@
+- type: entity
+  id: CrateVendingMachineRestockSeedsScpClassDFilled
+  parent: CrateHydroponics
+  name: MegaSeed restock crate
+  description: Contains a restock box for the MegaSeed vending machine.
+  components:
+  - type: StorageFill
+    contents:
+      - id: VendingMachineRestockSeedsScpClassD
+
+- type: entity
+  id: CrateVendingMachineRestockNutriMaxScpClassDFilled
+  parent: CrateHydroponics
+  name: NutriMax restock crate
+  description: Contains a restock box for the NutriMax vending machine.
+  components:
+  - type: StorageFill
+    contents:
+      - id: VendingMachineRestockNutriMaxScpClassD
+
+- type: entity
+  id: CrateVendingMachineRestockChefvendScpClassDFilled
+  parent: CratePlastic
+  name: ChefVend restock crate
+  description: Contains a restock box for the ChefVend.
+  components:
+  - type: StorageFill
+    contents:
+      - id: VendingMachineRestockChefvendScpClassD
+
+- type: entity
+  id: CrateVendingMachineRestockDinnerwareScpClassDFilled
+  parent: CratePlastic
+  name: Plasteel Chef restock crate
+  description: Contains a restock box for the Plasteel Chef vending machine.
+  components:
+  - type: StorageFill
+    contents:
+      - id: VendingMachineRestockDinnerwareScpClassD
+
+- type: entity
+  id: CrateVendingMachineRestockBoozeScpClassDFilled
+  parent: CratePlastic
+  name: Booze-O-Mat restock crate
+  description: Contains a restock box for the Booze-O-Mat.
+  components:
+  - type: StorageFill
+    contents:
+      - id: VendingMachineRestockBoozeScpClassD

--- a/Resources/Prototypes/_Scp/Entities/Objects/Specific/Service/vending_machine_restock.yml
+++ b/Resources/Prototypes/_Scp/Entities/Objects/Specific/Service/vending_machine_restock.yml
@@ -1,0 +1,50 @@
+
+- type: entity
+  parent: VendingMachineRestockSeeds
+  id: VendingMachineRestockSeedsScpClassD
+  name: Seed restock box
+  description: A label says they're heirloom seeds, passed down from our ancestors. Pack it into the Seed Servitor!
+  components:
+  - type: VendingMachineRestock
+    canRestock:
+    - MegaSeedServitorInventoryDClass
+
+- type: entity
+  parent: VendingMachineRestockNutriMax
+  id: VendingMachineRestockNutriMaxScpClassD
+  name: NutriMax restock box
+  description: We'll make your thumbs green with our tools. Let's get to harvesting! Load into a NutriMax vending machine.
+  components:
+  - type: VendingMachineRestock
+    canRestock:
+    - NutriMaxInventoryDClass
+
+- type: entity
+  parent: VendingMachineRestockChefvend
+  id: VendingMachineRestockChefvendScpClassD
+  name: ChefVend restock box
+  description: Refill the ChefVend. Just don't break any more of the eggs.
+  components:
+  - type: VendingMachineRestock
+    canRestock:
+    - ChefvendInventoryDClass
+
+- type: entity
+  parent: VendingMachineRestockDinnerware
+  id: VendingMachineRestockDinnerwareScpClassD
+  name: Plasteel Chef's restock box
+  description: It's never raw in this kitchen! Drop into the restock slot on the Plasteel Chef to begin.
+  components:
+  - type: VendingMachineRestock
+    canRestock:
+    - DinnerwareInventoryDClass
+
+- type: entity
+  parent: VendingMachineRestockBooze
+  id: VendingMachineRestockBoozeScpClassD
+  name: Booze-O-Mat restock box
+  description: Slot into your Booze-O-Mat! Not for sale.
+  components:
+  - type: VendingMachineRestock
+    canRestock:
+    - BoozeOMatInventoryDClass

--- a/Resources/Prototypes/_Scp/Entities/Structures/Machines/vending_machines.yml
+++ b/Resources/Prototypes/_Scp/Entities/Structures/Machines/vending_machines.yml
@@ -163,25 +163,11 @@
     access: [["Service"]]
 
 - type: entity
-  parent: VendingMachineDinnerware
-  id: ScpVendingMachineDinnerwareClassD
-  components:
-  - type: AccessReader
-    access: [["ClassDCanteen"]]
-
-- type: entity
   parent: VendingMachineNutri
   id: ScpVendingMachineNutri
   components:
   - type: AccessReader
     access: [["Service"]]
-
-- type: entity
-  parent: VendingMachineNutri
-  id: ScpVendingMachineNutriClassD
-  components:
-  - type: AccessReader
-    access: [["ClassDCanteen"]]
 
 - type: entity
   parent: VendingMachineSeeds
@@ -191,25 +177,11 @@
     access: [["Service"]]
 
 - type: entity
-  parent: VendingMachineSeeds
-  id: ScpVendingMachineSeedsClassD
-  components:
-  - type: AccessReader
-    access: [["ClassDCanteen"]]
-
-- type: entity
   parent: VendingMachineHydrobe
   id: ScpVendingMachineHydrobe
   components:
   - type: AccessReader
     access: [["Service"]]
-
-- type: entity
-  parent: VendingMachineHydrobe
-  id: ScpVendingMachineHydrobeClassD
-  components:
-  - type: AccessReader
-    access: [["ClassDCanteen"]]
 
 - type: entity
   parent: VendingMachineLawDrobe
@@ -246,13 +218,6 @@
   components:
   - type: AccessReader
     access: [["Service"]]
-
-- type: entity
-  parent: VendingMachineChefDrobe
-  id: ScpVendingMachineChefDrobeClassD
-  components:
-  - type: AccessReader
-    access: [["ClassDCanteen"]]
 
 - type: entity
   parent: VendingMachineJaniDrobe


### PR DESCRIPTION
## Краткое описание
Добавил возможность пополнять Вендоматы Д класса.
А так же удалил ненужные дубли вендоматов д класса.

## Медиа(Видео/Скриншоты)
<img width="581" height="162" alt="image" src="https://github.com/user-attachments/assets/e1b3e894-6a31-45cc-986c-f70d2ad405eb" />

**Changelog**
:cl: Parashut
- add: Добавлены наборы для пополнения Вендоматов Д класса.
- tweak: Теперь набор пополнения одеждомата так же пополняет ШефВенд Д класса.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Новые функции
  - Добавлены ящики и коробки пополнения для MegaSeed, NutriMax, ChefVend, Plasteel Chef и Booze-O-Mat; доступны для заказа в карго (разные стоимости).
  - Расширены варианты пополнения гардероба: добавлена поддержка ChefDrobe.
- Локализация
  - Добавлены русские названия и описания для новых коробок и ящиков пополнения.
- Рефактор
  - Удалены устаревшие D-класс варианты нескольких торговых автоматов с доступом столовой.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->