### PR TITLE
Хот-фикс лифта

### DIFF
--- a/Resources/Prototypes/_Scp/Entities/Structures/Machines/complex_elevator.yml
+++ b/Resources/Prototypes/_Scp/Entities/Structures/Machines/complex_elevator.yml
@@ -1,5 +1,4 @@
 - type: entity
-  parent: BaseMachine
   id: ComplexElevator
   name: Elevator
   suffix: "Elevator of the complex"
@@ -14,8 +13,6 @@
   - type: Icon
     sprite: _Scp/Structures/elevator.rsi
     state: steel
-  - type: Transform
-    anchored: true
   - type: Clickable
   - type: Physics
     bodyType: Static


### PR DESCRIPTION
## Краткое описание
Исправил то что лифты можно было двигать тянув из-за того что лифт наследовал BaseMachine.
## Сссылка на багрепорт/ТЗ/Предложение
## Медиа(Видео/Скриншоты)

**Changelog**
:cl: Neyran
- fix: Исправлена проблема что лифты можно двигаться перетягивая его как обычный предмет или открепленную структуру.

