### PR TITLE
Исправление SCP-106

### DIFF
--- a/Content.Server/_Scp/Scp106/Systems/Scp106System.cs
+++ b/Content.Server/_Scp/Scp106/Systems/Scp106System.cs
@@ -135,8 +135,8 @@ public sealed partial class Scp106System : SharedScp106System
         if (!HasComp<HumanoidAppearanceComponent>(target))
             return;
 
-        // Не телепортировать трупы
-        if (_mobState.IsDead(target))
+        // Не телепортировать трупы, если 106 не фантом
+        if (_mobState.IsDead(target) && scp106 != null)
             return;
 
         await TeleportToBackroomsInternal(target);


### PR DESCRIPTION
<!-- Текст в стрелочках является комментариями - они не будут видны в вашем PR. -->

## Краткое описание
<!-- Что вы предлагаете изменить с помощью своего PR? -->
Трупы теперь телепортируются в измерение 106 при реверсии будучи фантомом.

<!--
## TODO

Не закончили? Добавьте список того, что требуется для завершения PR`а
-->

**Changelog**

<!--
КАК ПИСАТЬ ЧЕЙНЖЛОГ:

1) Не считайте тип чейнжлога частью вашего предложения. Так не принято. То есть:
add: Новая фича = ПЛОХО
add: Добавлена новая фича = ХОРОШО

2) Подробно описывайте, что вы добавили и как это использовать/найти. Главное не переусердствуйте. Все должно быть в меру

fix: Исправлены мелочи = УЖАСНО
fix: Исправлены некоторые баги в коде сцп 173 = ПЛОХО
fix: Исправлена невозможность сцп173 двигаться = ХОРОШО

3) Не добавляйте в чейнжлог технические детали вашего изменения. Чейнжлог для игроков, пишите его для игроков. Им не нужно знать технические детали

add: Добавлен новый хелпер-метод в систему сцп106 = ПЛОХО
НИЧЕГО НЕ ПИСАТЬ = ХОРОШО.

Иногда чейнжог не нужен. Просто удалите это поле

-->

:cl: Mr_Samuel
- fix: Исправлено отсутствие телепорта трупов после реверсии с фантомом SCP-106

