### PR TITLE
Исправление SCP-106 

### DIFF
--- a/Content.Server/_Scp/Scp106/Systems/Scp106System.cs
+++ b/Content.Server/_Scp/Scp106/Systems/Scp106System.cs
@@ -136,7 +136,7 @@ public sealed partial class Scp106System : SharedScp106System
             return;
 
         // Не телепортировать трупы
-        if (_mobState.IsDead(target))
+        if (_mobState.IsDead(target) && scp106 != null)
             return;
 
         await TeleportToBackroomsInternal(target);


### PR DESCRIPTION
<!-- Текст в стрелочках является комментариями - они не будут видны в вашем PR. -->

## Краткое описание
<!-- Что вы предлагаете изменить с помощью своего PR? -->
Трупы теперь телепортируются в измерение 106 при реверсии будучи фантомом.

:cl: Mr_Samuel
- fix: Исправлено отсутствие телепорта трупов после реверсии с фантомом SCP-106



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Исправления ошибок**
  * Отрегулирована механика телепортации мёртвых целей для SCP-106. Изменены условия взаимодействия объекта с неживыми существами, что может повлиять на игровые сценарии и тактику использования в различных ситуациях.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->