### PR TITLE
Фикс спрайта P90

### DIFF
--- a/Resources/Prototypes/_Sunrise/Entities/Objects/Weapons/Guns/SMGs/smgs.yml
+++ b/Resources/Prototypes/_Sunrise/Entities/Objects/Weapons/Guns/SMGs/smgs.yml
@@ -14,6 +14,8 @@
       map: ["enum.GunVisualLayers.Base"]
     - state: mag-0
       map: ["enum.GunVisualLayers.Mag"]
+  - type: Clothing # Fire Edit
+    sprite: _Sunrise/Objects/Weapons/Guns/SMGs/p90.rsi
   - type: GunWieldBonus
     minAngle: -2.9
     maxAngle: -30


### PR DESCRIPTION
## Краткое описание
Фиксанул отображение П90 за спиной.

**Changelog**
:cl: Parashut
- fix: Исправлено отображение P90 на спине.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Заметки о выпуске

* **Новые возможности**
  * Обновлена визуализация P-90: добавлен новый слой визуального отображения для улучшенного внешнего вида оружия.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->