### PR TITLE
Активация досрочного запуска

### DIFF
--- a/Resources/Prototypes/Entities/Structures/Machines/Computers/computers.yml
+++ b/Resources/Prototypes/Entities/Structures/Machines/Computers/computers.yml
@@ -100,7 +100,7 @@
   components:
   - type: AccessReader
     access:
-    - [ Command ]
+    - [ Exit ] # Fire Edit
   - type: EmergencyShuttleConsole
   - type: ActivatableUI
     key: enum.EmergencyConsoleUiKey.Key


### PR DESCRIPTION
## Краткое описание
Изменил доступы на ранний старт эвака.
Ждать 480 секунд при чёрном когда когда все кто мог уже на эваке - не ок.

**Changelog**
:cl: Parashut
- tweak: Теперь Администрация комплекса может активировать досрочный запуск эвакуационного шаттла.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Примечания к выпуску

* **Изменения**
  * Обновлены права доступа к консоли аварийного шаттла: теперь персонал с правом доступа "Exit" может управлять экстренной эвакуацией вместо персонала с правом доступа "Command".

<!-- end of auto-generated comment: release notes by coderabbit.ai -->