### PR TITLE
Удаление афродизиака с НаноМеда

### DIFF
--- a/Resources/Prototypes/Catalog/VendingMachines/Inventories/wallmed.yml
+++ b/Resources/Prototypes/Catalog/VendingMachines/Inventories/wallmed.yml
@@ -11,6 +11,8 @@
   contrabandInventory:
     PowerCellSmall: 2
     AntiPoisonMedipen: 1 # Sunrise Edit
-    PatchViagra: 2 # Sunrise Edit
+    # Fire Edit - delete PatchViagra
+    #PatchViagra: 2 # Sunrise Edit
+    #
   emaggedInventory:
     StimpackMini: 1 # Sunrise Edit


### PR DESCRIPTION
## Краткое описание
Удаление афродизиака с НаноМеда

:cl: Wardex
- remove: Удален афродизиак с каталога НаноМеда



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Исправления ошибок

* Удален неактивный предмет из инвентаря торгового автомата.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->