### PR TITLE
Правка телепортации между картами у Артефактов

### DIFF
--- a/Resources/Prototypes/_Scp/Research/tables.yml
+++ b/Resources/Prototypes/_Scp/Research/tables.yml
@@ -42,6 +42,8 @@
       #    - id: ScpEffectPolyTable
       #      weight: 2
       # Сломано TODO: вернём после фикса
+    - id: ScpArtifactShuffle
+      weight: 2
 #    - id: ScpEffectCreateArtifacts
 #      weight: 1
 # Пока не работает
@@ -142,6 +144,8 @@
     children:
     - id: ScpEffectShuffleUltra
       weight: 0.01
+    - id: ScpArtifactShuffle
+      weight: 2
     - id: EffectMagnetUltra
       weight: 1
     - id: ScpEffectShiftedAsciiTableAccent


### PR DESCRIPTION
## Краткое описание
Заменил эффект у SCP Артефактов `ScpEffectSwap`, который перемещал предметы между разными картами другим эффектом `ScpArtifactShuffle` что перемещает объекты в определённом радиусе по карте.

## Сссылка на багрепорт/ТЗ/Предложение
Частые жалобы от Администрации, а так же инциденты где с Админ арены пропадали Debug сущности и вместо них с комплекса прилетали игроки.

**Changelog**
:cl: Parashut
- fix: Исправлен узел у SCP который телепортировал игроков между картами (в основном на админ арену).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Исправлены эффекты артефактов в таблицах исследования. Обновлена механика перемешивания артефактов для обеспечения корректного функционирования во всех режимах исследовательской деятельности и конфигурациях.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->