### PR TITLE
Удаление SCP-005 из случайного спавна

### DIFF
--- a/Resources/Prototypes/_Scp/Entities/Backrooms/misc.yml
+++ b/Resources/Prototypes/_Scp/Entities/Backrooms/misc.yml
@@ -43,7 +43,6 @@
     - ScpAnomalySwatter
     - ScpAnomalyDollar
     - ScpAnomalyCoffee
-    - ScpAnomalyKey
     - ScpAnomalyBook
     - ScpAnomalySpawnWand
     - ScpAnomalyRedCore


### PR DESCRIPTION
## Краткое описание
Удалил дубль SCP-005 из случайного спавна. Бессмысленный SCP Item.
Чейнджлог не стал записывать.

**Changelog**
:cl: Parashut
- remove: Удалён дубль ключа SCP-005 из случайного спавна SCP предметов.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Исправления ошибок**
  * Удалена возможность появления определённого аномального артефакта в списке случайно генерируемой добычи. Игроки больше не будут встречать этот предмет при открытии лут-контейнеров в соответствующих зонах игрового мира.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->