### PR TITLE
Попытка исправить отсутствие Scp106AscentRule

### DIFF
--- a/Content.Server/_Scp/Scp106/Systems/Scp106System.cs
+++ b/Content.Server/_Scp/Scp106/Systems/Scp106System.cs
@@ -242,7 +242,7 @@ public sealed partial class Scp106System : SharedScp106System
             if (mobStateComponent.CurrentState != MobState.Alive)
                 continue;
 
-            if (TryComp<SSDIndicatorComponent>(humanUid, out var ssd) && !ssd.IsSSD)
+            if (TryComp<SSDIndicatorComponent>(humanUid, out var ssd) && ssd.IsSSD)
                 continue;
 
             humansInBackrooms += 1;


### PR DESCRIPTION
<!-- Текст в стрелочках является комментариями - они не будут видны в вашем PR. -->

## Краткое описание
<!-- Что вы предлагаете изменить с помощью своего PR? -->
Попытка фикса 106-го? Бля, да он же вайбкодер!

## Сссылка на багрепорт/ТЗ/Предложение
<!-- В чём причина добавления этих изменений? Ссылки на Дискуссии, а так-же Баг-Репорты указывать здесь. Пожалуйста опишите как это изменит игровой баланс. -->
https://discord.com/channels/1051873590301184031/1479193579414098041

## Медиа(Видео/Скриншоты)
<!--
Если ваш PR содержит внутриигровые изменения вы обязаны предоставить скриншоты/видео изменений.
-->

<!--
## TODO

Не закончили? Добавьте список того, что требуется для завершения PR`а
-->

**Changelog**

<!--
КАК ПИСАТЬ ЧЕЙНЖЛОГ:

1) Не считайте тип чейнжлога частью вашего предложения. Так не принято. То есть:
add: Новая фича = ПЛОХО
add: Добавлена новая фича = ХОРОШО

2) Подробно описывайте, что вы добавили и как это использовать/найти. Главное не переусердствуйте. Все должно быть в меру

fix: Исправлены мелочи = УЖАСНО
fix: Исправлены некоторые баги в коде сцп 173 = ПЛОХО
fix: Исправлена невозможность сцп173 двигаться = ХОРОШО

3) Не добавляйте в чейнжлог технические детали вашего изменения. Чейнжлог для игроков, пишите его для игроков. Им не нужно знать технические детали

add: Добавлен новый хелпер-метод в систему сцп106 = ПЛОХО
НИЧЕГО НЕ ПИСАТЬ = ХОРОШО.

Иногда чейнжог не нужен. Просто удалите это поле

-->

:cl: NotSoWizard
- fix: Исправление отсутствия Scp106AscentRule после отправки 10 активных игроков в измерение SCP-106

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Исправления ошибок
* Исправлена логика подсчета персонажей в Backrooms. Система теперь корректно определяет и считает персонажей в соответствии с их статусом защиты. Изменение предотвращает неправильный учет персонажей и обеспечивает точные данные о населении в Backrooms.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->