### PR TITLE
issue-761: chore: option for adjusting FOV blindness effect

### DIFF
--- a/Content.Client/_Scp/Options/UI/Tabs/ScpTab.xaml
+++ b/Content.Client/_Scp/Options/UI/Tabs/ScpTab.xaml
@@ -20,6 +20,9 @@
                                  ToolTip="{Loc ui-options-grain-strength-tooltip}"/>
 
                 <!-- Поле зрения -->
+                <CheckBox Name="FieldOfViewBlurEnabled"
+                          Text="{Loc ui-options-field-of-view-blur-enabled}"
+                          ToolTip="{Loc ui-options-field-of-view-blur-enabled-tooltip}"/>
                 <ui:OptionSlider Name="FieldOfViewBlurScale"
                                  Title="{Loc ui-options-field-of-view-blur-scale}"
                                  ToolTip="{Loc ui-options-field-of-view-blur-scale-tooltip}"/>

--- a/Content.Client/_Scp/Options/UI/Tabs/ScpTab.xaml.cs
+++ b/Content.Client/_Scp/Options/UI/Tabs/ScpTab.xaml.cs
@@ -32,6 +32,7 @@ public sealed partial class ScpTab : Control
             GrainOverlayComponent.BaseStrengthLimit.Min, GrainOverlayComponent.BaseStrengthLimit.Max);
 
         // Поле зрения
+        Control.AddOptionCheckBox(ScpCCVars.FieldOfViewBlurEnabled, FieldOfViewBlurEnabled);
         Control.AddOptionPercentSlider(ScpCCVars.FieldOfViewOpacity, FieldOfViewOpacitySlider,
             FieldOfViewComponent.MinOpacity, FieldOfViewComponent.MaxOpacity);
         Control.AddOptionPercentSlider(ScpCCVars.FieldOfViewBlurScale, FieldOfViewBlurScale,
@@ -85,6 +86,7 @@ public sealed partial class ScpTab : Control
         ToggleBloom();
         ToggleBloomCone();
         ToggleEcho();
+        ToggleFovBlur();
     }
 
     protected override void EnteredTree()
@@ -95,6 +97,7 @@ public sealed partial class ScpTab : Control
         LightBloomEnable.OnToggled += ToggleBloom;
         LightBloomConeEnable.OnToggled += ToggleBloomCone;
         EchoEnabled.OnToggled += ToggleEcho;
+        FieldOfViewBlurEnabled.OnToggled += ToggleFovBlur;
     }
 
     protected override void ExitedTree()
@@ -105,6 +108,7 @@ public sealed partial class ScpTab : Control
         LightBloomEnable.OnToggled -= ToggleBloom;
         LightBloomConeEnable.OnToggled -= ToggleBloomCone;
         EchoEnabled.OnToggled -= ToggleEcho;
+        FieldOfViewBlurEnabled.OnToggled -= ToggleFovBlur;
     }
 
     private void ToggleGrain(BaseButton.ButtonToggledEventArgs value = default!)
@@ -130,5 +134,10 @@ public sealed partial class ScpTab : Control
     private void ToggleEcho(BaseButton.ButtonToggledEventArgs value = default!)
     {
         EchoStrongPresetPreferred.Visible = EchoEnabled.Pressed;
+    }
+
+    private void ToggleFovBlur(BaseButton.ButtonToggledEventArgs value = default!)
+    {
+        FieldOfViewBlurScale.Visible = FieldOfViewBlurEnabled.Pressed;
     }
 }

--- a/Content.Client/_Scp/Shaders/FieldOfView/FieldOfViewOverlayManagementSystem.cs
+++ b/Content.Client/_Scp/Shaders/FieldOfView/FieldOfViewOverlayManagementSystem.cs
@@ -75,7 +75,8 @@ public sealed class FieldOfViewOverlayManagementSystem : EntitySystem
 
         _configSub = _cfg.SubscribeMultiple()
             .OnValueChanged(ScpCCVars.FieldOfViewBlurScale, x => _coneOverlay.BlurScale = x, true)
-            .OnValueChanged(ScpCCVars.FieldOfViewOpacity, x => _coneOverlay.Opacity = x, true);
+            .OnValueChanged(ScpCCVars.FieldOfViewOpacity, x => _coneOverlay.Opacity = x, true)
+            .OnValueChanged(ScpCCVars.FieldOfViewBlurEnabled, x => _coneOverlay.BlurEnabled = x, true);
     }
 
     public override void Shutdown()

--- a/Content.Client/_Scp/Shaders/FieldOfView/Overlays/FieldOfViewConeOverlay.cs
+++ b/Content.Client/_Scp/Shaders/FieldOfView/Overlays/FieldOfViewConeOverlay.cs
@@ -48,6 +48,11 @@ public sealed class FieldOfViewConeOverlay : Overlay
     /// </summary>
     public float Opacity = 0.85f;
 
+    /// <summary>
+    /// Whether blur is enabled outside the field of view
+    /// </summary>
+    public bool BlurEnabled = true;
+
     private static readonly Vector2 OffsetVectorFix = new (1, -1);
 
     /// <summary>
@@ -88,9 +93,19 @@ public sealed class FieldOfViewConeOverlay : Overlay
         if (args.Viewport.Eye != player.Comp1.Eye)
             return false;
 
+        var res = _resources.GetForViewport(args.Viewport, static _ => new CachedResources());
+
+        if (!BlurEnabled)
+        {
+            res.BackBuffer?.Dispose();
+            res.BackBuffer = null;
+            res.BlurPass?.Dispose();
+            res.BlurPass = null;
+            return true;
+        }
+
         var size = (Vector2i)(args.Viewport.Size * BlurScale);
 
-        var res = _resources.GetForViewport(args.Viewport, static _ => new CachedResources());
         if (res.BackBuffer == null || res.BackBuffer.Size != size)
         {
             res.BackBuffer?.Dispose();
@@ -109,27 +124,33 @@ public sealed class FieldOfViewConeOverlay : Overlay
             return;
 
         var res = _resources.GetForViewport(args.Viewport, static _ => new CachedResources());
-        if (res.BackBuffer == null || res.BlurPass == null)
+        if (BlurEnabled && (res.BackBuffer == null || res.BlurPass == null))
             return;
 
         var (uid, eye, fov, xform) = _fovManagement.PlayerEntity.Value;
 
         var handle = args.WorldHandle;
         var viewport = args.WorldBounds;
-        var viewportBounds = new Box2(Vector2.Zero, res.BlurPass.Size);
 
-        if (_timing.RealTime >= _nextUpdate)
+        if (BlurEnabled && _timing.RealTime >= _nextUpdate)
         {
-            handle.RenderInRenderTarget(res.BlurPass, () =>
+            if (res.BackBuffer == null || res.BlurPass == null)
+                return;
+
+            var backBuffer = res.BackBuffer;
+            var blurPass = res.BlurPass;
+            var viewportBounds = new Box2(Vector2.Zero, blurPass.Size);
+
+            handle.RenderInRenderTarget(blurPass, () =>
             {
                 _blurXShader.SetParameter("SCREEN_TEXTURE", ScreenTexture);
                 handle.UseShader(_blurXShader);
                 handle.DrawRect(viewportBounds, Color.White);
             }, Color.Transparent);
 
-            handle.RenderInRenderTarget(res.BackBuffer, () =>
+            handle.RenderInRenderTarget(backBuffer, () =>
             {
-                _blurYShader.SetParameter("SCREEN_TEXTURE", res.BlurPass.Texture);
+                _blurYShader.SetParameter("SCREEN_TEXTURE", blurPass.Texture);
                 handle.UseShader(_blurYShader);
                 handle.DrawRect(viewportBounds, Color.White);
             }, Color.Transparent);
@@ -138,9 +159,10 @@ public sealed class FieldOfViewConeOverlay : Overlay
         }
 
         var offset = GetOffset(uid, xform, eye);
+        var blurredTexture = BlurEnabled && res.BackBuffer != null ? res.BackBuffer.Texture : ScreenTexture;
 
         _shader.SetParameter("SCREEN_TEXTURE", ScreenTexture);
-        _shader.SetParameter("BLURRED_TEXTURE", res.BackBuffer.Texture);
+        _shader.SetParameter("BLURRED_TEXTURE", blurredTexture);
         _shader.SetParameter("coneOpacity", Opacity);
 
         _shader.SetParameter("ViewAngle", (float) fov.CurrentAngle.Theta);

--- a/Content.Shared/_Scp/ScpCCVars/ScpCCVars.Graphics.cs
+++ b/Content.Shared/_Scp/ScpCCVars/ScpCCVars.Graphics.cs
@@ -25,13 +25,19 @@ public sealed partial class ScpCCVars
     /// Размер текстуры размытия у шейдера поля зрения
     /// </summary>
     public static readonly CVarDef<float> FieldOfViewBlurScale =
-        CVarDef.Create("shader.field_of_view_blur_scale", 0.7f, CVar.CLIENTONLY | CVar.ARCHIVE);
+        CVarDef.Create("shader.field_of_view_blur_scale", 1.0f, CVar.CLIENTONLY | CVar.ARCHIVE);
 
     /// <summary>
     /// Прозрачность наложения поля зрения
     /// </summary>
     public static readonly CVarDef<float> FieldOfViewOpacity =
-        CVarDef.Create("shader.field_of_view_opacity", 0.7f, CVar.CLIENTONLY | CVar.ARCHIVE);
+        CVarDef.Create("shader.field_of_view_opacity", 0.55f, CVar.CLIENTONLY | CVar.ARCHIVE);
+
+    /// <summary>
+    /// Whether the blur effect outside the field of view is enabled
+    /// </summary>
+    public static readonly CVarDef<bool> FieldOfViewBlurEnabled =
+        CVarDef.Create("shader.field_of_view_blur_enabled", true, CVar.CLIENTONLY | CVar.ARCHIVE);
 
     /*
      * Режим совместимости

--- a/Content.Shared/_Scp/Watching/FOV/FieldOfViewComponent.cs
+++ b/Content.Shared/_Scp/Watching/FOV/FieldOfViewComponent.cs
@@ -9,7 +9,7 @@ namespace Content.Shared._Scp.Watching.FOV;
 public sealed partial class FieldOfViewComponent : Component
 {
     public const float MaxOpacity = 0.95f;
-    public const float MinOpacity = 0.55f;
+    public const float MinOpacity = 0.15f;
 
     public const float MaxBlurScale = 1f;
     public const float MinBlurScale = 0.25f;

--- a/Resources/Locale/en-US/_strings/_scp/ui/options.ftl
+++ b/Resources/Locale/en-US/_strings/_scp/ui/options.ftl
@@ -10,6 +10,8 @@ ui-options-grain-strength = Grain shader strength
 ui-options-grain-strength-tooltip =
     Determines the intensity of the grain shader effects.
     The higher the value, the more "noise" there will be on the screen
+ui-options-field-of-view-blur-enabled = Enable FOV blur
+ui-options-field-of-view-blur-enabled-tooltip = Blurs the area outside your field of view. Disable for better performance or if you find it distracting.
 ui-options-field-of-view-blur-scale = Blur texture quality
 ui-options-field-of-view-blur-scale-tooltip =
     Determines the quality of the blur texture. The larger, the more resource-intensive the texture

--- a/Resources/Locale/ru-RU/_strings/_scp/ui/options.ftl
+++ b/Resources/Locale/ru-RU/_strings/_scp/ui/options.ftl
@@ -14,6 +14,8 @@ ui-options-grain-strength = Сила шейдера зернистости
 ui-options-grain-strength-tooltip =
     Определяет интенсивность эффектов шейдера зернистости.
     Чем больше, тем больше будет "шуршания" на экране
+ui-options-field-of-view-blur-enabled = Размытие поля зрения
+ui-options-field-of-view-blur-enabled-tooltip = Размывает область за пределами поля зрения. Отключите для повышения производительности или если эффект мешает.
 ui-options-field-of-view-blur-scale = Качество текстуры размытия
 ui-options-field-of-view-blur-scale-tooltip =
     Определяет качество текстуры размытия. Чем больше, тем более ресурсозатратная текстура


### PR DESCRIPTION
## Description

Addresses player feedback that the field of view overlay is visually uncomfortable and difficult to configure. Makes the blur effect toggleable, lowers the default opacity, raises the default blur quality, and expands the minimum opacity range

## Related Issue/Bug Report

Closes #761

## Media

<img width="693" height="70" alt="image" src="https://github.com/user-attachments/assets/bc09791a-cbe7-427f-aa31-d2e5a4ad5563" />


## Testing

- Blur toggle checkbox correctly shows and hides the blur effect behind the character
- Blur quality slider hides when blur is disabled since it has no effect
- Default opacity is lower than before
- Default blur quality is 100% instead of 70%
- Opacity slider minimum is now 15% instead of 55%

**Changelog**

:cl: rokudara
- tweak: Lowered the default field of view overlay opacity and raised the default blur quality
- tweak: Expanded the minimum opacity range so players can lower the darkness significantly
- add: Added a toggle to disable the FOV blur effect entirely for players who find it distracting

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Релиз-ноты

* **Новые функции**
  * Добавлена опция в настройках для включения/отключения размытия за пределами поля зрения.
  * Интерфейс показывает/скрывает параметр масштаба размытия в зависимости от состояния переключателя.

* **Изменения**
  * Обновлены значения по умолчанию для масштаба размытия и прозрачности поля зрения.
  * Понижено минимальное значение прозрачности для эффекта поля зрения.

* **Локализация**
  * Добавлены тексты и подсказки для новой опции на русском и английском.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->