### PR TITLE
Инструменты для 049

### DIFF
--- a/Resources/Prototypes/_Scp/Entities/Clothing/Bags/scp049.yml
+++ b/Resources/Prototypes/_Scp/Entities/Clothing/Bags/scp049.yml
@@ -36,4 +36,6 @@
     - id: Cautery
     - id: Retractor
     - id: Scalpel
+    - id: BoneSetter
+    - id: BoneGel
     - id: Scp049Contract


### PR DESCRIPTION
<!-- RU: Текст в стрелочках является комментариями — они не будут видны в вашем PR. -->
<!-- EN: Text within arrows are comments — they will not be visible in your PR. -->

## Краткое описание | Short description
Добавил в сумку SCP-049 бутылочку костного геля и костоправ. Инструменты в проведении операций обязательны, игрокам приходилось их искать в комнатах/запрашивать.

**Changelog**

:cl: Vashkentya
- add: добавил костоправ и бутылочку костного геля в сумку SCP-049


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Новая версия

* **Новые функции**
  * Расширен набор предметов в специализированном рюкзаке. Добавлены два новых медицинских инструмента, которые теперь доступны как часть стандартного комплекта предметов.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->