### PR TITLE
get out!

### DIFF
--- a/Resources/Prototypes/Catalog/VendingMachines/Inventories/cola.yml
+++ b/Resources/Prototypes/Catalog/VendingMachines/Inventories/cola.yml
@@ -11,7 +11,7 @@
     DrinkFourteenLokoCan: 2
   contrabandInventory:
     DrinkColaBottleFull: 2
-    DrinkChangelingStingCan: 2
+    #DrinkChangelingStingCan: 2 # Fire edit
     DrinkBeerCan: 2 #Sunrise-Edit
   emaggedInventory:
     DrinkNukieCan: 2

--- a/Resources/Prototypes/Catalog/VendingMachines/Inventories/gib.yml
+++ b/Resources/Prototypes/Catalog/VendingMachines/Inventories/gib.yml
@@ -13,7 +13,7 @@
     ClothingNeckStethoscope: 2
     Saw: 2
     Tourniquet: 3
-    DrinkChangelingStingCan: 2
+    #DrinkChangelingStingCan: 2 # Fire edit
     DrinkBeerCan: 2 #Sunrise-Edit
   emaggedInventory:
     DrinkNukieCan: 2

--- a/Resources/Prototypes/Catalog/VendingMachines/Inventories/pwrgame.yml
+++ b/Resources/Prototypes/Catalog/VendingMachines/Inventories/pwrgame.yml
@@ -12,7 +12,7 @@
     DrinkFourteenLokoCan: 2
   contrabandInventory:
     DrinkDrGibbCan: 3
-    DrinkChangelingStingCan: 2
+    #DrinkChangelingStingCan: 2 # Fire edit
     DrinkBeerCan: 2 #Sunrise-Edit
   emaggedInventory:
     DrinkNukieCan: 2

--- a/Resources/Prototypes/Catalog/VendingMachines/Inventories/shamblersjuice.yml
+++ b/Resources/Prototypes/Catalog/VendingMachines/Inventories/shamblersjuice.yml
@@ -10,7 +10,7 @@
     DrinkLemonLimeCranberryCan: 2
     DrinkFourteenLokoCan: 2
   contrabandInventory:
-    DrinkChangelingStingCan: 2
+    #DrinkChangelingStingCan: 2 # Fire edit
     DrinkBeerCan: 2 #Sunrise-Edit
   emaggedInventory:
     DrinkNukieCan: 2

--- a/Resources/Prototypes/Catalog/VendingMachines/Inventories/smite.yml
+++ b/Resources/Prototypes/Catalog/VendingMachines/Inventories/smite.yml
@@ -8,7 +8,7 @@
   contrabandInventory:
     DrinkStarkistCan: 2
     ToyHammer: 1
-    DrinkChangelingStingCan: 2
+    #DrinkChangelingStingCan: 2 # Fire edit
     DrinkBeerCan: 2 #Sunrise-Edit
   emaggedInventory:
     DrinkNukieCan: 2

--- a/Resources/Prototypes/Catalog/VendingMachines/Inventories/soda.yml
+++ b/Resources/Prototypes/Catalog/VendingMachines/Inventories/soda.yml
@@ -11,6 +11,6 @@
     DrinkFourteenLokoCan: 3
   contrabandInventory:
     DrinkColaBottleFull: 2
-    DrinkChangelingStingCan: 3
+    #DrinkChangelingStingCan: 3 # Fire edit
   emaggedInventory:
     DrinkNukieCan: 3

--- a/Resources/Prototypes/Catalog/VendingMachines/Inventories/spaceup.yml
+++ b/Resources/Prototypes/Catalog/VendingMachines/Inventories/spaceup.yml
@@ -11,6 +11,6 @@
   contrabandInventory:
     DrinkSpaceMountainWindBottleFull: 2
     DrinkSpaceUpBottleFull: 2
-    DrinkChangelingStingCan: 2
+    #DrinkChangelingStingCan: 2 # Fire edit
   emaggedInventory:
     DrinkNukieCan: 2

--- a/Resources/Prototypes/Catalog/VendingMachines/Inventories/starkist.yml
+++ b/Resources/Prototypes/Catalog/VendingMachines/Inventories/starkist.yml
@@ -11,6 +11,6 @@
     DrinkFourteenLokoCan: 2
   contrabandInventory:
     FoodBurgerCarp: 2
-    DrinkChangelingStingCan: 2
+    #DrinkChangelingStingCan: 2 # Fire edit
   emaggedInventory:
     DrinkNukieCan: 2

--- a/Resources/Prototypes/Entities/Markers/Spawners/Random/Food_Drinks/drinks_soda.yml
+++ b/Resources/Prototypes/Entities/Markers/Spawners/Random/Food_Drinks/drinks_soda.yml
@@ -32,7 +32,7 @@
     children:
     - id: DrinkBeerCan
     - id: DrinkCafeLatte
-    - id: DrinkChangelingStingCan
+    #- id: DrinkChangelingStingCan # Fire edit
     - id: DrinkColaBottleFull
     - id: DrinkColaCan
     - id: DrinkDrGibbCan

--- a/Resources/Prototypes/Entities/Mobs/NPCs/mimic.yml
+++ b/Resources/Prototypes/Entities/Mobs/NPCs/mimic.yml
@@ -40,7 +40,9 @@
   - type: MovementSpeedModifier
     baseWalkSpeed : 1
     baseSprintSpeed : 1
-  - type: Butcherable
-    spawned:
-    - id: DrinkChangelingStingCan
-      amount: 1
+  # Fire edit start
+  #- type: Butcherable
+  #  spawned:
+  #  - id: DrinkChangelingStingCan
+  #    amount: 1
+  # Fire edit end

--- a/Resources/Prototypes/_Scp/Entities/Objects/Scp/scp261.yml
+++ b/Resources/Prototypes/_Scp/Entities/Objects/Scp/scp261.yml
@@ -81,7 +81,7 @@
   - type: GuideHelp
     guides:
     - ScpResearch
-          
+
 - type: entity
   id: Scp261Spawner
   categories: [ HideSpawnMenu ]
@@ -90,6 +90,7 @@
     rarePrototypes:
     - Scp330CandyRed
     - Scp207Bottle
+    - DrinkChangelingStingCan
     rareChance: 0.03
     prototypes:
     - FoodSnackSwirlLollipop


### PR DESCRIPTION
## Краткое описание | Short description
Удаление Жала Генокрада отовсюду и добавление его же в Scp261

:cl: Wardex
- remove: Жало Генокрада удалено со всех возможных автоматах
- add: Жало Генокрада добавлено в Scp261

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Отрегулирована доступность определённого напитка в игре. Удалено из нескольких торговых автоматов и случайных спаунеров, добавлено в список редких предметов специального спаунера для улучшения игрового баланса.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->