### PR TITLE
Fix stamp goal

### DIFF
--- a/Content.Server/_Sunrise/StationGoal/StationGoalPaperSystem.cs
+++ b/Content.Server/_Sunrise/StationGoal/StationGoalPaperSystem.cs
@@ -81,10 +81,10 @@ namespace Content.Server._Sunrise.StationGoal
                 Loc.GetString("station-goal-fax-paper-name"),
                 null,
                 null,
-                "paper_stamp-centcom",
+                "paper_stamp-hos", // Fire-Edit
                 new List<StampDisplayInfo>
                 {
-                    new() { StampedName = Loc.GetString("stamp-component-stamped-name-centcom"), StampedColor = Color.Green },
+                    new() { StampedName = Loc.GetString("stamp-component-stamped-name-regional-command"), StampedColor = Color.FromHex("#CC0000FF") }, // Fire-Edit
                 },
                 imageContent: header);
 


### PR DESCRIPTION
<!-- RU: Текст в стрелочках является комментариями — они не будут видны в вашем PR. -->
<!-- EN: Text within arrows are comments — they will not be visible in your PR. -->

## Краткое описание | Short description
Была заменена печать ЦентКома на печать РУ в целях смен

**Changelog**

:cl: Vashkentya
- fix: заменил печать ЦентКома в целях смен на печать Регионального Управления


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Исправления

* Обновлено визуальное отображение печатей на документах целей станции. Изменены параметры представления печати, включая её внешний вид и цветовую схему (переход от зеленого к красному цвету). Эти изменения обеспечивают лучшую визуальную идентификацию и классификацию документов в системе управления станцией.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->