### PR TITLE
Мизирные изменения 049 и 082

### DIFF
--- a/Resources/Prototypes/_Scp/Entities/Mobs/Player/Scp/Main/scp049.yml
+++ b/Resources/Prototypes/_Scp/Entities/Mobs/Player/Scp/Main/scp049.yml
@@ -91,3 +91,4 @@
     defaultRotation: 90
     horizontalRotation: 90
   - type: Perishable
+  - type: HoldToFace

--- a/Resources/Prototypes/_Scp/Entities/Mobs/Player/Scp/Main/scp082.yml
+++ b/Resources/Prototypes/_Scp/Entities/Mobs/Player/Scp/Main/scp082.yml
@@ -49,6 +49,8 @@
   - type: MovementSpeedModifier
     baseWalkSpeed: 1.5
     baseSprintSpeed: 2.5
+  - type: ScpRestriction
+    canPull: true
   - type: Pullable
   - type: Puller
     needsHands: true
@@ -77,3 +79,4 @@
     guides:
     - ScpResearch
     - ScpFear
+  - type: HoldToFace

--- a/Resources/Prototypes/_Scp/Entities/Mobs/Player/Scp/Main/scp082.yml
+++ b/Resources/Prototypes/_Scp/Entities/Mobs/Player/Scp/Main/scp082.yml
@@ -80,3 +80,12 @@
     - ScpResearch
     - ScpFear
   - type: HoldToFace
+  - type: Prying
+    enabled: false
+    pryPowered: true
+    force: true
+    speedModifier: 0.9
+    useSound:
+      path: /Audio/_Scp/Scp096/prydoor.ogg
+      params:
+        volume: -4

--- a/Resources/Prototypes/_Scp/Entities/Mobs/Player/Scp/Main/scp082.yml
+++ b/Resources/Prototypes/_Scp/Entities/Mobs/Player/Scp/Main/scp082.yml
@@ -28,6 +28,8 @@
     requiredLegs: 2
   - type: Inventory
     templateId: scp082
+  - type: FieldOfView
+    angle: 240
   - type: Sprite
     noRot: true
     drawdepth: Mobs


### PR DESCRIPTION
<!-- RU: Текст в стрелочках является комментариями — они не будут видны в вашем PR. -->
<!-- EN: Text within arrows are comments — they will not be visible in your PR. -->

## Краткое описание | Short description
Добавил компонент HoldToFace SCP-049 и SCP-082, так как они у нас очеловеченные.
Добавил ScpRestriction 082-му, чтобы мог таскать предметы (труп на кухню), FieldOfView, ведь он тот же человек по сути, поле зрения должно у него быть, как и у 049. И Prying для открытия шлюзов со скросостью чуть больше, чем у скромника.
Я понимаю, что фиксы 082 могут быть бесполезны, однако подобное даст ему хоть что-то при спавнах админами на ивенты, а не куском овоща, способным только взять, ударить и сожрать.

**Changelog**

:cl: Vashkentya
- add: Добавил возможность за SCP-049 смотреть в направлении мыши;
- add: Добавил возможность за SCP-082 смотреть в направлении мыши, поле зрения, способность тянуть предметы и вскрывать шлюзы.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Новые функции**
  * Добавлены механики взаимодействия для SCP-049.
  * Расширены способности восприятия и взаимодействия для SCP-082, включая улучшенный радиус обзора и новые опции взаимодействия с окружением.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->