### PR TITLE
Удаление Р.И.Г из лодаутов

### DIFF
--- a/Resources/Prototypes/Entities/Structures/stairs.yml
+++ b/Resources/Prototypes/Entities/Structures/stairs.yml
@@ -9,7 +9,7 @@
   - type: Anchorable
     flags:
     - Anchorable
-  - type: Rotatable
+ #- type: Rotatable # Fire-edit, stairs don't need to be rotatable
   - type: Clickable
   - type: Sprite
     sprite: Structures/stairs.rsi

--- a/Resources/Prototypes/_Scp/Loadouts/common.yml
+++ b/Resources/Prototypes/_Scp/Loadouts/common.yml
@@ -147,4 +147,3 @@
   - ScpLoadoutClothingBackpack
   - ScpLoadoutClothingBackpackSatchel
   - ScpLoadoutClothingBackpackDuffel
-  - ScpLoadoutClothingCommonModsuit


### PR DESCRIPTION
## Краткое описание | Short description
Удаление Р.И.Г и лодаута ролей Гастронома и Обслуживающего персонала. Убрал компонент вращения ступенькам.

**Ссылка на баг-репорты:**
https://discord.com/channels/1051873590301184031/1493996363673767978

**Changelog**

:cl: Vashkentya
- remove: Удалён спонсорский Р.И.Г из лодаутов Гастронома и Обслуживающего персонала
- fix: Исправлена возможность поворачивать ступеньки

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Изменения**
  * Удалена опция комбинезона из доступного набора готовых комплектов экипировки.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->