### PR TITLE
Мелочи по 173, 049 и 082

### DIFF
--- a/Content.Server/_Scp/Scp173/Scp173System.cs
+++ b/Content.Server/_Scp/Scp173/Scp173System.cs
@@ -63,6 +63,8 @@ public sealed partial class Scp173System : SharedScp173System
 
     private TimeSpan _nextReagentCheck;
 
+    private EntityQuery<SubFloorHideComponent> _subFloorQuery;
+
     public override void Initialize()
     {
         base.Initialize();
@@ -70,6 +72,7 @@ public sealed partial class Scp173System : SharedScp173System
         SubscribeLocalEvent<Scp173Component, Scp173DamageStructureAction>(OnStructureDamage);
         SubscribeLocalEvent<Scp173Component, Scp173ClogAction>(OnClog);
         SubscribeLocalEvent<Scp173Component, Scp173FastMovementAction>(OnFastMovement);
+        _subFloorQuery = GetEntityQuery<SubFloorHideComponent>();
     }
 
     public override void Update(float frameTime)
@@ -133,8 +136,7 @@ public sealed partial class Scp173System : SharedScp173System
         foreach (var ent in lookup)
         {
             // Проверяем, скрыта ли труба под плиткой
-            var isUnderCover = TryComp<SubFloorHideComponent>(ent, out var subFloor) && subFloor.IsUnderCover;
-            if (isUnderCover)
+            if (_subFloorQuery.TryComp(ent, out var subFloor) && subFloor.IsUnderCover && subFloor.BlockInteractions)
                 continue; // Не ломаем то, что под полом
 
             // Наносим случайным вещам структурный дамаг

--- a/Content.Server/_Scp/Scp173/Scp173System.cs
+++ b/Content.Server/_Scp/Scp173/Scp173System.cs
@@ -121,7 +121,7 @@ public sealed partial class Scp173System : SharedScp173System
             return;
         }
 
-        var lookup = _lookup.GetEntitiesInRange(uid, 4f, LookupFlags.Static)
+        var lookup = _lookup.GetEntitiesInRange(uid, 4f)
             .Where(ent => _interaction.InRangeUnobstructed(uid.Owner, ent, ExamineSystemShared.ExamineRange));
 
         var entityStorage = GetEntityQuery<EntityStorageComponent>();
@@ -132,11 +132,6 @@ public sealed partial class Scp173System : SharedScp173System
 
         foreach (var ent in lookup)
         {
-            // Проверяем, скрыта ли труба под плиткой
-            var isUnderCover = TryComp<SubFloorHideComponent>(ent, out var subFloor) && subFloor.IsUnderCover;
-            if (isUnderCover)
-                continue; // Не ломаем то, что под полом
-
             // Наносим случайным вещам структурный дамаг
             var dspec = new DamageSpecifier();
             var damageValue = _random.Next(20, 80);

--- a/Content.Server/_Scp/Scp173/Scp173System.cs
+++ b/Content.Server/_Scp/Scp173/Scp173System.cs
@@ -26,7 +26,6 @@ using Content.Shared.Lock;
 using Content.Shared.Physics;
 using Content.Shared.Popups;
 using Content.Shared.Storage.Components;
-using Content.Shared.SubFloor;
 using Robust.Server.Audio;
 using Robust.Server.GameObjects;
 using Robust.Shared.Audio;

--- a/Content.Server/_Scp/Scp173/Scp173System.cs
+++ b/Content.Server/_Scp/Scp173/Scp173System.cs
@@ -63,8 +63,6 @@ public sealed partial class Scp173System : SharedScp173System
 
     private TimeSpan _nextReagentCheck;
 
-    private EntityQuery<SubFloorHideComponent> _subFloorQuery;
-
     public override void Initialize()
     {
         base.Initialize();
@@ -72,7 +70,6 @@ public sealed partial class Scp173System : SharedScp173System
         SubscribeLocalEvent<Scp173Component, Scp173DamageStructureAction>(OnStructureDamage);
         SubscribeLocalEvent<Scp173Component, Scp173ClogAction>(OnClog);
         SubscribeLocalEvent<Scp173Component, Scp173FastMovementAction>(OnFastMovement);
-        _subFloorQuery = GetEntityQuery<SubFloorHideComponent>();
     }
 
     public override void Update(float frameTime)
@@ -124,7 +121,7 @@ public sealed partial class Scp173System : SharedScp173System
             return;
         }
 
-        var lookup = _lookup.GetEntitiesInRange(uid, 4f)
+        var lookup = _lookup.GetEntitiesInRange(uid, 4f, LookupFlags.Static)
             .Where(ent => _interaction.InRangeUnobstructed(uid.Owner, ent, ExamineSystemShared.ExamineRange));
 
         var entityStorage = GetEntityQuery<EntityStorageComponent>();
@@ -136,7 +133,8 @@ public sealed partial class Scp173System : SharedScp173System
         foreach (var ent in lookup)
         {
             // Проверяем, скрыта ли труба под плиткой
-            if (_subFloorQuery.TryComp(ent, out var subFloor) && subFloor.IsUnderCover && subFloor.BlockInteractions)
+            var isUnderCover = TryComp<SubFloorHideComponent>(ent, out var subFloor) && subFloor.IsUnderCover;
+            if (isUnderCover)
                 continue; // Не ломаем то, что под полом
 
             // Наносим случайным вещам структурный дамаг

--- a/Content.Server/_Scp/Scp173/Scp173System.cs
+++ b/Content.Server/_Scp/Scp173/Scp173System.cs
@@ -26,6 +26,7 @@ using Content.Shared.Lock;
 using Content.Shared.Physics;
 using Content.Shared.Popups;
 using Content.Shared.Storage.Components;
+using Content.Shared.SubFloor;
 using Robust.Server.Audio;
 using Robust.Server.GameObjects;
 using Robust.Shared.Audio;
@@ -131,6 +132,11 @@ public sealed partial class Scp173System : SharedScp173System
 
         foreach (var ent in lookup)
         {
+            // Проверяем, скрыта ли труба под плиткой
+            var isUnderCover = TryComp<SubFloorHideComponent>(ent, out var subFloor) && subFloor.IsUnderCover;
+            if (isUnderCover)
+                continue; // Не ломаем то, что под полом
+
             // Наносим случайным вещам структурный дамаг
             var dspec = new DamageSpecifier();
             var damageValue = _random.Next(20, 80);

--- a/Resources/Prototypes/_Scp/Entities/Clothing/Bags/scp049.yml
+++ b/Resources/Prototypes/_Scp/Entities/Clothing/Bags/scp049.yml
@@ -26,6 +26,7 @@
       - SunriseUplink # рыбаплинк
       - PillCanister
       - Pen
+      - Bottle
   - type: StorageFill
     contents:
     - id: BookScp049Diary

--- a/Resources/Prototypes/_Scp/Entities/Mobs/Player/Scp/Main/scp049.yml
+++ b/Resources/Prototypes/_Scp/Entities/Mobs/Player/Scp/Main/scp049.yml
@@ -47,7 +47,6 @@
   - type: Hands
   - type: Body
     prototype: Human
-    requiredLegs: 2
   - type: ComplexInteraction
   - type: Buckle
   - type: Stripping

--- a/Resources/Prototypes/_Scp/Entities/Mobs/Player/Scp/Main/scp082.yml
+++ b/Resources/Prototypes/_Scp/Entities/Mobs/Player/Scp/Main/scp082.yml
@@ -34,6 +34,8 @@
     templateId: scp082
   - type: FieldOfView
     angle: 240
+  - type: Hunger
+  - type: Thirst
   - type: Sprite
     noRot: true
     drawdepth: Mobs
@@ -51,10 +53,11 @@
       enum.StoreUiKey.Key:
         type: StoreBoundUserInterface
   - type: MovementSpeedModifier
-    baseWalkSpeed: 1.5
-    baseSprintSpeed: 2.5
+    baseWalkSpeed: 1.5 # TO DO: добиться изменения его скорости до указанных значений, на данный момент при спавне ему задается значение 2.5 и меняется из-за Fixtures
+    baseSprintSpeed: 2.5 # TO DO: добиться изменения его скорости до указанных значений, на данный момент при спавне ему задается значение 4.5 и меняется из-за Fixtures
   - type: ScpRestriction
     canPull: true
+    canCarry: true
   - type: Pullable
   - type: Puller
     needsHands: true
@@ -70,6 +73,9 @@
     - DoorBumpOpener
   - type: MeleeWeapon
     hidden: true
+    altDisarm: false
+    animation: WeaponArcPunch
+    wideAnimation: WeaponArcPunch
     soundHit:
       collection: Punch
     damage:
@@ -77,6 +83,9 @@
         Blunt: 40
     attackRate: 1.25
     range: 2
+  - type: MeleeThrowOnHit
+    speed: 2
+    distance: 0.25
   - type: TTS
     voice: Dota2Pudge
   - type: GuideHelp
@@ -93,3 +102,20 @@
       path: /Audio/_Scp/Scp096/prydoor.ogg
       params:
         volume: -4
+  - type: Bloodstream
+    bloodRefreshAmount: 5
+    bloodReferenceSolution:
+      reagents:
+      - ReagentId: Blood
+        Quantity: 1500
+  - type: Fixtures
+    fixtures:
+      fix1:
+        shape:
+          !type:PhysShapeAabb
+          bounds: "-0.25,-0.4,0.25,0.4"
+        density: 500
+        mask:
+        - MobMask
+        layer:
+        - MobLayer

--- a/Resources/Prototypes/_Scp/Entities/Mobs/Player/Scp/Main/scp082.yml
+++ b/Resources/Prototypes/_Scp/Entities/Mobs/Player/Scp/Main/scp082.yml
@@ -52,8 +52,8 @@
       enum.StoreUiKey.Key:
         type: StoreBoundUserInterface
   - type: MovementSpeedModifier
-    baseWalkSpeed: 1.5 # TO DO: добиться изменения его скорости до указанных значений, на данный момент при спавне ему задается значение 2.5 и меняется из-за Fixtures
-    baseSprintSpeed: 2.5 # TO DO: добиться изменения его скорости до указанных значений, на данный момент при спавне ему задается значение 4.5 и меняется из-за Fixtures
+    baseWalkSpeed: 1.5
+    baseSprintSpeed: 2.5
   - type: ScpRestriction
     canPull: true
   - type: Pullable

--- a/Resources/Prototypes/_Scp/Entities/Mobs/Player/Scp/Main/scp082.yml
+++ b/Resources/Prototypes/_Scp/Entities/Mobs/Player/Scp/Main/scp082.yml
@@ -57,7 +57,6 @@
     baseSprintSpeed: 2.5 # TO DO: добиться изменения его скорости до указанных значений, на данный момент при спавне ему задается значение 4.5 и меняется из-за Fixtures
   - type: ScpRestriction
     canPull: true
-    canCarry: true
   - type: Pullable
   - type: Puller
     needsHands: true
@@ -74,8 +73,8 @@
   - type: MeleeWeapon
     hidden: true
     altDisarm: false
-    animation: WeaponArcPunch
-    wideAnimation: WeaponArcPunch
+    animation: WeaponArcSmash
+    wideAnimation: WeaponArcSmash
     soundHit:
       collection: Punch
     damage:

--- a/Resources/Prototypes/_Scp/Entities/Mobs/Player/Scp/Main/scp082.yml
+++ b/Resources/Prototypes/_Scp/Entities/Mobs/Player/Scp/Main/scp082.yml
@@ -29,7 +29,6 @@
       10000: Dead
   - type: Body
     prototype: Human
-    requiredLegs: 2
   - type: Inventory
     templateId: scp082
   - type: FieldOfView


### PR DESCRIPTION
<!-- RU: Текст в стрелочках является комментариями — они не будут видны в вашем PR. -->
<!-- EN: Text within arrows are comments — they will not be visible in your PR. -->

## Краткое описание | Short description
Добавил откидывание сущностей от ударов 082 как у 096. Добавил возможность удара по области через ПКМ. Добавил возможность брать на руки других существ и носить так. Добавил Fixtures, после которого 082 обрел "вес", пониженную скорость передвижения и скорость поднятия существ. Добавлена механика голода и жажды для 082. Увеличено количество крови у 082 и скорость ее регенерации, так как при нескольких ударов ножом игрок за 082 получал все отрицательные эффекты (расплывчатость камеры, заикания), хотя урон для него несущественный.
Добавил возможность 049-му класть в свою сумку химические бутылочки.

**Changelog**

:cl: Vashkentya
- add: Удары SCP-082 теперь откидывают цель. Добавлена возможность удара по области на ПКМ.
- fix: SCP-082 теперь передвигается со соответствующей скоростью.
- add: SCP-082 обрел голод и жажду.
- add: SCP-049 теперь может складывать в свою сумку химические бутылочки.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Исправления ошибок**
  * Урон от конструкций больше не применяется к объектам, скрытым под полом

* **Новые функции**
  * Рюкзак SCP-049 теперь принимает бутылки
  * SCP-082 получил голод и жажду
  * SCP-082 может переносить предметы и его ближние атаки отбрасывают цели при попадании
  * У SCP-082 улучшена система кровообращения с периодическим восстановлением крови
<!-- end of auto-generated comment: release notes by coderabbit.ai -->