### PR TITLE
Исправление урона Scp173

### DIFF
--- a/Content.Shared/_Scp/Other/DamageOnCollide/ScpDamageOnCollideComponent.cs
+++ b/Content.Shared/_Scp/Other/DamageOnCollide/ScpDamageOnCollideComponent.cs
@@ -39,4 +39,7 @@ public partial struct DamageOnCollideParameters()
 
     [DataField]
     public bool UseVariance = true;
+
+    [DataField]
+    public bool IgnoreResistances;
 }

--- a/Content.Shared/_Scp/Other/DamageOnCollide/ScpDamageOnCollideSystem.cs
+++ b/Content.Shared/_Scp/Other/DamageOnCollide/ScpDamageOnCollideSystem.cs
@@ -56,7 +56,7 @@ public sealed class ScpDamageOnCollideSystem : EntitySystem
             if (!CheckParameter(ent, target, param, requireVelocity))
                 continue;
 
-            _damageable.TryChangeDamage(target, param.Damage, ignoreVariance: !param.UseVariance);
+            _damageable.TryChangeDamage(target, param.Damage, ignoreVariance: !param.UseVariance, ignoreResistances: param.IgnoreResistances);
 
             _audio.PlayPredicted(param.TargetSound, target, ent);
             _audio.PlayPredicted(param.EntitySound, ent, ent);

--- a/Resources/Prototypes/_Scp/Entities/Mobs/Player/Scp/Main/scp173.yml
+++ b/Resources/Prototypes/_Scp/Entities/Mobs/Player/Scp/Main/scp173.yml
@@ -47,6 +47,7 @@
       damage:
         types:
           Blunt: 200
+      ignoreResistances: true
       targetSound:
         collection: Scp173NeckSnap
       useVariance: false
@@ -59,6 +60,7 @@
       damage:
         types:
           Blunt: 100
+      ignoreResistances: true
       targetSound:
         path: /Audio/_Scp/Scp173/smash.ogg
         params:


### PR DESCRIPTION
## Краткое описание | Short description
Scp173 теперь игнорирует любую защиту при свертывании шеи

## Ссылка на багрепорт/Предложение | Related Issue/Bug Report
https://discord.com/channels/1051873590301184031/1498716212396429382

**Changelog**

:cl: Wardex
- fix: Scp173 теперь игнорирует любую защиту при свертывании шеи.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Релиз-заметки

* **Новые возможности**
  * Добавлена опция игнорирования резистентности для системы урона при столкновении.
  * Атаки SCP-173 при столкновении теперь игнорируют резистентность враждебных целей, обеспечивая гарантированный урон независимо от их защиты.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->