### PR TITLE
Chaos_Helmet

### DIFF
--- a/Resources/Prototypes/_Scp/Entities/Clothing/Head/helmets.yml
+++ b/Resources/Prototypes/_Scp/Entities/Clothing/Head/helmets.yml
@@ -6,6 +6,16 @@
     sprite: _Scp/Clothing/Head/Helmets/chaos.rsi
   - type: Clothing
     sprite: _Scp/Clothing/Head/Helmets/chaos.rsi
+  - type: Armor
+    modifiers:
+      coefficients:
+        Blunt: 0.9
+        Slash: 0.9
+        Piercing: 0.9
+        Heat: 0.9
+        Caustic: 0.95
+  - type: ExplosionResistance
+    damageCoefficient: 0.75
   - type: Tag
     tags:
     - WhitelistChameleon


### PR DESCRIPTION

## Краткое описание 

Добавляет шлему повстанцев хаоса резисты

**Changelog**

:cl: MrZero1984

- fix: исправлены резисты (вернее их отсутствие) у шлема повстанцев хаоса.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Улучшения**
  * Добавлена броневая защита шлему Хаоса с уменьшением урона от удара, порезов, пробивающего урона, теплового и кислотного воздействия.
  * Добавлена устойчивость к взрывам, снижающая получаемый урон на 25%.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/space-sunrise/project-fire/pull/1008?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->