### PR TITLE
Перенос MP-7 в "пистолеты" (терминал ПХ)

### DIFF
--- a/Resources/Prototypes/_Scp/Catalog/chaos_uplink_catalog.yml
+++ b/Resources/Prototypes/_Scp/Catalog/chaos_uplink_catalog.yml
@@ -13,17 +13,6 @@
     stock: 1
 
 - type: listing
-  id: ChaosUplinkWeaponMP7
-  productEntity: WeaponSubMachineGunMP7
-  cost:
-    SupplyPoint: 5
-  categories:
-  - ChaosWeaponRifle
-  conditions:
-  - !type:ListingLimitedStockCondition
-    stock: 1
-
-- type: listing
   id: ChaosUplinkWeaponAKMU
   productEntity: WeaponRifleAKMU
   cost:
@@ -148,7 +137,18 @@
   conditions:
   - !type:ListingLimitedStockCondition
     stock: 1
-
+    
+- type: listing
+  id: ChaosUplinkWeaponMP7
+  productEntity: WeaponSubMachineGunMP7
+  cost:
+    SupplyPoint: 5
+  categories:
+  - ChaosWeaponPistol
+  conditions:
+  - !type:ListingLimitedStockCondition
+    stock: 1
+    
 # region Ammo
 
 - type: listing


### PR DESCRIPTION
<!-- RU: Текст в стрелочках является комментариями — они не будут видны в вашем PR. -->
<!-- EN: Text within arrows are comments — they will not be visible in your PR. -->

## Краткое описание | Short description
MP-7 был перенесён из "Штурмовое оружие" в "Пистолеты" (терминал повстанцев хаоса).



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Изменения баланса**
  * MP7 переклассифицирован из категории винтовок в категорию пистолетов и подствольников с обновленными параметрами стоимости и ограничениями на закупку.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->