### PR TITLE
Исправление отображаемого уровня угрозы на аварийных светильниках

### DIFF
--- a/Content.Server/Light/EntitySystems/EmergencyLightSystem.cs
+++ b/Content.Server/Light/EntitySystems/EmergencyLightSystem.cs
@@ -72,7 +72,7 @@ public sealed class EmergencyLightSystem : SharedEmergencyLightSystem
             args.PushMarkup(
                 Loc.GetString("emergency-light-component-on-examine-alert",
                     ("color", color.ToHex()),
-                    ("level", Loc.GetString($"alert-level-{name.ToString().ToLower()}"))));
+                    ("level", Loc.GetString($"alert-level-{name.ToString()}")))); // Fire edit
         }
     }
 


### PR DESCRIPTION
## Краткое описание | Short description
Исправление отображаемого уровня угрозы на аварийных светильниках

:cl: Wardex
- fix: Теперь уровень угрозы корректно отображается на аварийных светильниках


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Исправлено отображение уровня оповещения при осмотре аварийного фонаря.
  * Теперь используется корректный ключ локализации, поэтому текст состояния должен показываться точнее и стабильнее.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->