### PR TITLE
Исправление костылей апстрима

### DIFF
--- a/Content.Shared/CCVar/CCVars.Audio.cs
+++ b/Content.Shared/CCVar/CCVars.Audio.cs
@@ -65,5 +65,5 @@ public sealed partial class CCVars
         /// </summary>
         [CVarControl(AdminFlags.VarEdit)]
         public static readonly CVarDef<string> LobbyMusicCollection =
-            CVarDef.Create("audio.lobby_music_collection", "SunriseLobbyMusic", CVar.REPLICATED | CVar.SERVER); // Sunrise-edit
+            CVarDef.Create("audio.lobby_music_collection", "ScpLobbyMusic", CVar.REPLICATED | CVar.SERVER); // Fire edit
 }

--- a/Content.Shared/_Sunrise/SunriseCCVars/SunriseCCVars.Storyteller.cs
+++ b/Content.Shared/_Sunrise/SunriseCCVars/SunriseCCVars.Storyteller.cs
@@ -8,7 +8,7 @@ public sealed partial class SunriseCCVars
     /// Whether the dynamic storyteller system is enabled.
     /// </summary>
     public static readonly CVarDef<bool> StorytellerEnabled =
-        CVarDef.Create("storyteller.enabled", true, CVar.SERVER | CVar.ARCHIVE);
+        CVarDef.Create("storyteller.enabled", false, CVar.SERVER | CVar.ARCHIVE); // Fire edit
 
     /// <summary>
     /// How often the storyteller system evaluates the station state (in seconds).

--- a/Resources/Prototypes/_Scp/Access/AccessGroup/jobs.yml
+++ b/Resources/Prototypes/_Scp/Access/AccessGroup/jobs.yml
@@ -140,10 +140,13 @@
   tags:
   - Maintenance
   - Checkpoint
+  - Research
   - Security
   - Medical
   - Bunker
   - Safe
+  - Euclid
+  - Keter
 
 # Научная служба
 

--- a/Resources/Prototypes/_Scp/Entities/Objects/Scp/scp268.yml
+++ b/Resources/Prototypes/_Scp/Entities/Objects/Scp/scp268.yml
@@ -1,5 +1,6 @@
-﻿- type: entity
+- type: entity
   id: Scp268
+  categories: [ HideSpawnMenu ] # Fire edit
   name: irish cap
   description: A worn-out headwear. It is surprisingly difficult to focus on.
   parent: [BaseItemScp, ClothingHeadBase]

--- a/Resources/migration.yml
+++ b/Resources/migration.yml
@@ -2852,4 +2852,7 @@ ClothingHandsGlovesDirector: ClothingHandsGlovesDirectorSpecial
 GunLockerFilledAK74: GunLockerFilledAK103
 WeaponRifleAK74: WeaponRifleAK103
 
+# Временное отключение объектов
+Scp268: null # Временно отключён из-за сломанности и потому что он стал "имбовым"
+
 # Fire added end


### PR DESCRIPTION
## Краткое описание | Short description
Исправление костылей апстрима

**Changelog**

:cl: Wardex
- tweak: Служба Безопасности получила доступ к объектам классов: Безопасный, Евклид, Кетер
- tweak: Scp268 временно вырезан из игры