### PR TITLE
Безопасное время для SCP457

### DIFF
--- a/Content.Server/_Scp/Scp457/Scp457System.cs
+++ b/Content.Server/_Scp/Scp457/Scp457System.cs
@@ -228,7 +228,7 @@ public sealed class Scp457System : EntitySystem
 
     private void TryChangeSize(Entity<Scp457Component> ent, float delta)
     {
-        if (_safeTime.IsInSafeTime(ent.Owner, false, false))
+        if (_safeTime.IsInSafeTime(ent.Owner, true, false))
             return;
 
         var component = ent.Comp;

--- a/Content.Server/_Scp/Scp457/Scp457System.cs
+++ b/Content.Server/_Scp/Scp457/Scp457System.cs
@@ -4,6 +4,7 @@ using Content.Server._Sunrise.VentCraw;
 using Content.Server.Stack;
 using Content.Shared._Scp.Helpers;
 using Content.Shared._Scp.Other.Events;
+using Content.Shared._Scp.SafeTime;
 using Content.Shared._Scp.Scp457;
 using Content.Shared.Atmos.Components;
 using Content.Shared.Chemistry.Components;
@@ -19,7 +20,6 @@ using Content.Shared.Item;
 using Content.Shared.Materials;
 using Content.Shared.Physics;
 using Content.Shared.Stacks;
-using Content.Shared.Weapons.Melee.Events;
 using Robust.Shared.Physics;
 using Robust.Shared.Physics.Events;
 using Robust.Shared.Physics.Systems;
@@ -34,6 +34,7 @@ public sealed class Scp457System : EntitySystem
     [Dependency] private readonly DamageableSystem _damageable = default!;
     [Dependency] private readonly EntityLookupSystem _lookup = default!;
     [Dependency] private readonly SharedPhysicsSystem _physics = default!;
+    [Dependency] private readonly SharedSafeTimeSystem _safeTime = default!;
     [Dependency] private readonly ScaleSpriteSystem _scaleSprite = default!;
     [Dependency] private readonly SharedSolutionContainerSystem _solution = default!;
     [Dependency] private readonly StackSystem _stack = default!;
@@ -44,7 +45,7 @@ public sealed class Scp457System : EntitySystem
     private EntityQuery<ReactiveComponent> _reactiveQuery;
     private EntityQuery<PhysicalCompositionComponent> _compositionQuery;
 
-    private TimeSpan DecayInterval = TimeSpan.FromSeconds(12);
+    private TimeSpan DecayInterval = TimeSpan.FromSeconds(18);
 
     public override void Initialize()
     {
@@ -227,6 +228,9 @@ public sealed class Scp457System : EntitySystem
 
     private void TryChangeSize(Entity<Scp457Component> ent, float delta)
     {
+        if (_safeTime.IsInSafeTime(ent.Owner, false, false))
+            return;
+
         var component = ent.Comp;
         var oldSize = component.ObjectSize;
         var newSize = Math.Clamp(oldSize + delta, component.MinimumObjectSize, component.ObjectSizeLimit);

--- a/Content.Shared/_Scp/SafeTime/SafeTimeComponent.cs
+++ b/Content.Shared/_Scp/SafeTime/SafeTimeComponent.cs
@@ -17,6 +17,12 @@ public sealed partial class SafeTimeComponent : Component
     public TimeSpan Time = TimeSpan.FromMinutes(15f);
 
     /// <summary>
+    /// Отсчёт должен начинатся от начала раунда или от текущего момента?
+    /// </summary>
+    [DataField]
+    public bool TimeFromRoundStart;
+
+    /// <summary>
     /// Время окончания безопасного времени <see cref="Time"/>
     /// </summary>
     [ViewVariables, AutoNetworkedField, AutoPausedField]

--- a/Content.Shared/_Scp/SafeTime/SafeTimeSystem.cs
+++ b/Content.Shared/_Scp/SafeTime/SafeTimeSystem.cs
@@ -36,7 +36,11 @@ public abstract class SharedSafeTimeSystem : EntitySystem
         DebugTools.Assert(ent.Comp.TimeEnd == null);
         DebugTools.Assert(ent.Comp.Time > TimeSpan.Zero);
 
-        ent.Comp.TimeEnd = _gameTicker.RoundStartTimeSpan + ent.Comp.Time;
+        if (ent.Comp.TimeFromRoundStart)
+            ent.Comp.TimeEnd = _gameTicker.RoundStartTimeSpan + ent.Comp.Time;
+        else
+            ent.Comp.TimeEnd = _timing.CurTime + ent.Comp.Time;
+
         Dirty(ent);
     }
 

--- a/Resources/Prototypes/_Scp/Actions/scp457.yml
+++ b/Resources/Prototypes/_Scp/Actions/scp457.yml
@@ -13,6 +13,7 @@
     raiseOnUser: true
   - type: InstantAction
     event: !type:Scp457AbsorbActionEvent
+  - type: SafeTimeRestricted
 
 - type: entity
   parent: BaseAction
@@ -32,3 +33,4 @@
     event: !type:InstantSpawnSpellEvent
       prototype: Scp457Flame
       posData: !type:TargetCasterPos
+  - type: SafeTimeRestricted

--- a/Resources/Prototypes/_Scp/Entities/Mobs/Player/Scp/Main/scp457.yml
+++ b/Resources/Prototypes/_Scp/Entities/Mobs/Player/Scp/Main/scp457.yml
@@ -22,6 +22,7 @@
       shader: unshaded
       map: [ "enum.DamageStateVisualLayers.Base" ]
   - type: SafeTime
+    timeFromRoundStart: false
   - type: Scp
     class: Euclid
   - type: Scp457

--- a/Resources/Prototypes/_Scp/Entities/Mobs/Player/Scp/Main/scp457.yml
+++ b/Resources/Prototypes/_Scp/Entities/Mobs/Player/Scp/Main/scp457.yml
@@ -21,6 +21,7 @@
     - state: fireguy
       shader: unshaded
       map: [ "enum.DamageStateVisualLayers.Base" ]
+  - type: SafeTime
   - type: Scp
     class: Euclid
   - type: Scp457


### PR DESCRIPTION
## Краткое описание
Безопасное время для SCP457

**Changelog**

:cl: Wardex
- add: Добавлено безопасное время, во время которого Scp457 не сможет сбежать (в первые 15 минут раунда)
- tweak: Интервал сгорания Scp457 увеличен с 12 до 18 секунд


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Изменения в игровом процессе**
  * Во время safe time размер SCP-457 больше не изменяется.
  * Интервал автоматического уменьшения размера увеличен с 12 до 18 секунд.
  * Способности поглощения и поджигания SCP-457 теперь недоступны во время safe time.
  * Для разных ситуаций safe time используется корректный отсчёт: с начала раунда или с момента активации.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->