### PR TITLE
Включение новых целей в игру, исправления 082 и амнезиака

### DIFF
--- a/Content.Server/_Scp/Scp082/Scp082System.cs
+++ b/Content.Server/_Scp/Scp082/Scp082System.cs
@@ -7,7 +7,9 @@ using Content.Shared._Scp.Scp082;
 using Content.Shared._Scp.Shaders.Highlighting;
 using Content.Shared.Body.Components;
 using Content.Shared.Body.Events;
+using Content.Shared.Damage.Systems;
 using Content.Shared.Humanoid;
+using Content.Shared.Mobs;
 using Content.Shared.Mobs.Systems;
 using Content.Shared.Popups;
 using Robust.Shared.Random;
@@ -23,6 +25,7 @@ public sealed class Scp082System : SharedScp082System
     [Dependency] private readonly MetabolizerSystem _metabolizer = default!;
     [Dependency] private readonly MobStateSystem _mobState = default!;
     [Dependency] private readonly EntityLookupSystem _lookup = default!;
+    [Dependency] private readonly DamageableSystem _damageable = default!;
     [Dependency] private readonly IGameTiming _timing = default!;
     [Dependency] private readonly IRobustRandom _random = default!;
 
@@ -33,6 +36,7 @@ public sealed class Scp082System : SharedScp082System
         base.Initialize();
         SubscribeLocalEvent<Scp082Component, MapInitEvent>(OnMapInit);
         SubscribeLocalEvent<Scp082Component, ScpIngestionConsumedEvent>(OnIngestionConsumed);
+        SubscribeLocalEvent<Scp082Component, MobStateChangedEvent>(OnMobStateChanged);
         SubscribeLocalEvent<Scp082Component, ComponentShutdown>(OnShutdown);
     }
 
@@ -43,9 +47,9 @@ public sealed class Scp082System : SharedScp082System
         var query = EntityQueryEnumerator<Scp082Component>();
         while (query.MoveNext(out var uid, out var component))
         {
-            if (_mobState.IsDead(uid))
+            if (_mobState.IsCritical(uid))
             {
-                ClearHighlights(uid);
+                _damageable.TryChangeDamage(uid, component.CriticalStateHealingRate * frameTime);
                 continue;
             }
 
@@ -105,6 +109,12 @@ public sealed class Scp082System : SharedScp082System
 
         SetHunger(entity.Owner, entity.Comp, entity.Comp.Hunger - hungerRestore);
         Dirty(entity);
+    }
+
+    private void OnMobStateChanged(Entity<Scp082Component> ent, ref MobStateChangedEvent args)
+    {
+        if (args.NewMobState == MobState.Dead)
+            ClearHighlights(ent);
     }
 
     private void SetHunger(EntityUid uid, Scp082Component component, float hunger)

--- a/Content.Shared/_Scp/Scp082/Scp082Component.cs
+++ b/Content.Shared/_Scp/Scp082/Scp082Component.cs
@@ -1,5 +1,5 @@
+using Content.Shared.Damage;
 using Robust.Shared.GameStates;
-using Robust.Shared.Serialization.TypeSerializers.Implementations.Custom;
 
 namespace Content.Shared._Scp.Scp082;
 
@@ -84,6 +84,27 @@ public sealed partial class Scp082Component : Component
         "scp082-rage-popup-1",
         "scp082-rage-popup-2",
         "scp082-rage-popup-3"
+    };
+
+    [DataField]
+    public DamageSpecifier CriticalStateHealingRate = new()
+    {
+        DamageDict = new()
+        {
+            { "Blunt", -20f },
+            { "Slash", -20f },
+            { "Piercing", -20f },
+            { "Heat", -20f },
+            { "Shock", -20f },
+            { "Bloodloss", -20f},
+            { "Genetic", -20f },
+            { "Toxin", -20f },
+            { "Airloss", -20f },
+            { "Asphyxiation", -20f },
+            { "Poison", -20f },
+            { "Radiation", -20f },
+            { "Cellular", -20f}
+        }
     };
 
     [ViewVariables]

--- a/Resources/Prototypes/_Scp/Entities/Mobs/Player/Scp/Main/scp082.yml
+++ b/Resources/Prototypes/_Scp/Entities/Mobs/Player/Scp/Main/scp082.yml
@@ -25,11 +25,23 @@
     minimumHolderCount: 3
   - type: Hands
     showInHands: false
+  - type: Appearance
   - type: MobThresholds
     thresholds:
       0: Alive
       1800: Critical
       2000: Dead
+  - type: DamageStateVisuals
+    states:
+      Alive:
+        Base: 082_fullbody
+        BaseUnshaded: tuxedo # временно, что бы не был голым
+      Critical:
+        Base: 082-dead
+        BaseUnshaded: tuxedo-dead # временно, что бы не был голым
+      Dead:
+        Base: 082-dead
+        BaseUnshaded: tuxedo-dead # временно, что бы не был голым
   - type: Body
     prototype: ScpPredator
   - type: Inventory
@@ -46,8 +58,10 @@
     drawdepth: Mobs
     sprite: _Scp/Mobs/Scp/scp-082.rsi
     layers:
-    - state: 082_fullbody
-    - state: tuxedo # временно чтобы он не был голым
+    - map: [ "enum.DamageStateVisualLayers.Base" ]
+      state: 082_fullbody
+    - map: [ "enum.DamageStateVisualLayers.BaseUnshaded" ]
+      state: tuxedo
   - type: ComplexInteraction
   - type: Buckle
   - type: ZombieImmune

--- a/Resources/Prototypes/_Scp/Entities/Objects/specific/amnesiac.yml
+++ b/Resources/Prototypes/_Scp/Entities/Objects/specific/amnesiac.yml
@@ -7,7 +7,7 @@
     currentLabel: reagent-amnesiac-raw-name
   - type: SolutionContainerManager
     solutions:
-      beaker:
+      drink:
         reagents:
         - ReagentId: RawAmnesiac
           Quantity: 50

--- a/Resources/Prototypes/_Scp/Entities/Stations/base.yml
+++ b/Resources/Prototypes/_Scp/Entities/Stations/base.yml
@@ -20,6 +20,10 @@
     - Scp6
     - Scp7
     - Scp8
+    - Scp9
+    - Scp10
+    - Scp11
+    - Scp12
 
 - type: entity
   id: BaseStationRegionalAdministration


### PR DESCRIPTION
## Краткое описание
Включение новых целей в игру, исправления 082 и амнезиака

:cl: Wardex
- tweak: Новые цели включены в раунды
- tweak: Scp082 теперь меняет спрайт при впадении в крит
- tweak: Scp082 теперь пассивно лечится в крите
- fix: Исправлен баг с пустым кувшином сырья с амнезиаком


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Новые возможности**
  * SCP-082 теперь восстанавливает здоровье в критическом состоянии.
  * Для SCP-082 добавлены визуальные состояния «жив», «критическое состояние» и «мёртв», включая корректную очистку подсветки после смерти.
  * В цели станции добавлены SCP-9, SCP-10, SCP-11 и SCP-12.
* **Исправления**
  * Для напитка Raw Amnesiac исправлено обозначение контейнера, что обеспечивает корректное взаимодействие с ним.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->